### PR TITLE
Keep the params order

### DIFF
--- a/lib/restapi/application.rb
+++ b/lib/restapi/application.rb
@@ -92,9 +92,9 @@ module Restapi
 
     # clear all saved data
     def clear_last
-      @last_api_args = Array.new
-      @last_errors = Array.new
-      @last_params = Hash.new
+      @last_api_args = []
+      @last_errors = []
+      @last_params = []
       @last_description = nil
     end
         

--- a/lib/restapi/dsl_definition.rb
+++ b/lib/restapi/dsl_definition.rb
@@ -69,7 +69,7 @@ module Restapi
     #   end
     #
     def param(param_name, *args, &block)
-      Restapi.last_params[param_name.to_sym] = Restapi::ParamDescription.new(param_name, *args, &block)
+      Restapi.last_params << Restapi::ParamDescription.new(param_name, *args, &block)
     end
     
     # create method api and redefine newly added method

--- a/lib/restapi/resource_description.rb
+++ b/lib/restapi/resource_description.rb
@@ -11,11 +11,11 @@ module Restapi
   class ResourceDescription
     
     attr_reader :_short_description, :_full_description, :_methods, :_id,
-      :_path, :_version, :_name, :_params
+      :_path, :_version, :_name, :_params_ordered
     
     def initialize(resource_name, &block)
       @_methods = []
-      @_params = Hash.new
+      @_params_ordered = []
 
       @_id = resource_name
       @_version = "1"
@@ -28,7 +28,8 @@ module Restapi
     end
     
     def param(param_name, *args, &block)
-      @_params[param_name.to_sym] = Restapi::ParamDescription.new(param_name, *args, &block)
+      param_description = Restapi::ParamDescription.new(param_name, *args, &block)
+      @_params_ordered << param_description
     end
     
     def path(path); @_path = path; end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -13,7 +13,7 @@ describe UsersController do
       a._methods.should include("users#create")
       a._methods.should include("users#index")
       a._methods.should include("users#two_urls")
-      md = a._params[:id]
+      md = a._params_ordered.find { |p| p.name == :id }
       md.should_not be(nil)
       md.name.should eq(:id)
       md.desc.should eq("\n<p>User ID</p>\n")
@@ -258,9 +258,6 @@ describe UsersController do
         :params => [{:required=>false,
                      :validator=>"Parameter has to be String.",
                      :description=>"\n<p>Authorization</p>\n", :name=>"oauth"},
-                    {:required=>false, :validator=>"Parameter has to be Integer.",
-                     :description=>"\n<p>Company ID</p>\n",
-                     :name=>"id"},
                     {:required=>true,
                      :validator=>"Parameter has to be String.",
                      :description=>"\n<p>Username for login</p>\n",
@@ -268,8 +265,11 @@ describe UsersController do
                     {:required=>true,
                      :validator=>"Parameter has to be String.",
                      :description=>"\n<p>Password for login</p>\n",
-                     :name=>"resource_param[password]"}               
-                   ],
+                     :name=>"resource_param[password]"},
+                    {:required=>false, :validator=>"Parameter has to be Integer.",
+                     :description=>"\n<p>Company ID</p>\n",
+                     :name=>"id"},
+       ],
         :name => :two_urls,
         :apis => [
           {


### PR DESCRIPTION
Using array instead of hash to keep the order of params so that when calling

```
param :name, String
param :street, String
```

the order will be always [:name, :street].
