### PR TITLE
array validator not accepting boolean attributes

### DIFF
--- a/lib/restapi/validator.rb
+++ b/lib/restapi/validator.rb
@@ -116,17 +116,7 @@ module Restapi
       end
 
       def validate(value)
-
-        @array.find do |expected|
-          expected_class = expected.class
-          expected_class = Integer if expected_class == Fixnum
-          begin
-            converted_value = Kernel.send(expected_class.to_s, value)
-          rescue ArgumentError
-            false
-          end
-          converted_value === expected
-        end
+        @array.include?(value)
       end
 
       def self.build(param_description, argument, options, proc)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -155,7 +155,7 @@ describe UsersController do
       assert_response :success
       get :show, :id => 5, :session => "secret_hash", :array_param => 1
       assert_response :success
-      get :show, :id => 5, :session => "secret_hash", :array_param => "2"
+      get :show, :id => 5, :session => "secret_hash", :boolean_param => false
       assert_response :success
     end
     

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -47,6 +47,7 @@ class UsersController < ApplicationController
   param :float_param, Float, :desc => "float param"
   param :regexp_param, /^[0-9]* years/, :desc => "regexp param"
   param :array_param, [100, "one", "two", 1, 2], :desc => "array validator"
+  param :boolean_param, [true, false], :desc => "array validator with boolean"
   param :proc_param, lambda { |val| 
     val == "param value" ? true : "The only good value is 'param value'."
   }, :desc => "proc validator"


### PR DESCRIPTION
when having something like:

```
param :recursive, [true, false]
```

the validator fails (undefined method `TrueClass' for Kernel:Module).

Simplifying the array validator not to try typecast the values for now. Maybe
there could be some option for that in the param to enable something like this
explicitly. Implicit conversions don't fit here very well. If I say I expect a
param to be one of [1, 2, 3] I might not be happy getting string instead of integer.
