### PR TITLE
handle Hash param without a block

### DIFF
--- a/lib/restapi/validator.rb
+++ b/lib/restapi/validator.rb
@@ -70,7 +70,7 @@ module Restapi
       end
 
       def self.build(param_description, argument, options, block)
-        self.new(param_description, argument) if argument.is_a?(Class) && argument != Hash
+        self.new(param_description, argument) if argument.is_a?(Class) && (argument != Hash || block.nil?)
       end
 
       def error

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -230,6 +230,13 @@ describe UsersController do
 
     end
 
+    it "it should support Hash validator without specifying keys" do
+      Restapi[UsersController, :create].to_json[:params].should include(:name => "facts",
+                                                                        :validator => "Parameter has to be Hash.",
+                                                                        :description => "\n<p>Additional optional facts about the user</p>\n",
+                                                                        :required => false)
+    end
+
   end
 
   describe 'two_urls' do

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -196,6 +196,7 @@ class UsersController < ApplicationController
     param :password, String, :desc => "Password for login", :required => true
     param :membership, ["standard","premium"], :desc => "User membership"
   end
+  param :facts, Hash, :desc => "Additional optional facts about the user"
   def create
     render :text => "OK"
   end


### PR DESCRIPTION
When specifying Hash param without a block it should be handled as
a TypeValidator. It was not able to find a validator before.
