### PR TITLE
fix 'uninitialized constant' error when API controllers in submodules

### DIFF
--- a/lib/restapi/application.rb
+++ b/lib/restapi/application.rb
@@ -22,30 +22,28 @@ module Restapi
     end
     
     # create new method api description
-    def define_method_description(resource_name, method_name)
-      resource_name = get_resource_name(resource_name)
-
-      puts "defining api for #{resource_name}:#{method_name}"
-
+    def define_method_description(controller, method_name)
       # create new or get existing api
+      resource_name = get_resource_name(controller)
       key = [resource_name, method_name].join('#')
-      @method_descriptions[key] ||=
-        Restapi::MethodDescription.new(method_name, resource_name, self)
-
       # add method description key to resource description
-      define_resource_description(resource_name).add_method(key)
+      resource = define_resource_description(controller)
+
+      method_description = Restapi::MethodDescription.new(method_name, resource, self)
+
+      @method_descriptions[key] ||= method_description
 
       @method_descriptions[key]
     end
 
     # create new resource api description
-    def define_resource_description(resource_name, &block)
-      resource_name = get_resource_name(resource_name)
-      
+    def define_resource_description(controller, &block)
+      resource_name = get_resource_name(controller)
+
       # puts "defining api for #{resource_name}"
-      
+
       @resource_descriptions[resource_name] ||=
-        Restapi::ResourceDescription.new(resource_name, &block)
+        Restapi::ResourceDescription.new(controller, resource_name, &block)
     end
 
     def add_method_description_args(args)

--- a/lib/restapi/method_description.rb
+++ b/lib/restapi/method_description.rb
@@ -34,10 +34,11 @@ module Restapi
       @errors = app.get_errors
       @params_ordered = app.get_params
 
-      parent = @resource.camelize.sub(/$/,'Controller').constantize.superclass
+      parent = @resource.controller.superclass
       if parent != ActionController::Base
         @parent_resource = parent.controller_name
       end
+      @resource.add_method("#{resource._id}##{method}")
     end
 
     def params
@@ -54,8 +55,7 @@ module Restapi
 
       # get params from actual resource description
       if @resource
-        resource = Restapi.get_resource_description(@resource)
-        merge_params(all_params, resource._params_ordered) if resource
+        merge_params(all_params, resource._params_ordered)
       end
 
       merge_params(all_params, @params_ordered)
@@ -66,7 +66,7 @@ module Restapi
       [
         ENV["RAILS_RELATIVE_URL_ROOT"],
         Restapi.configuration.doc_base_url,
-        "##{@resource}/#{@method}"
+        "##{@resource._id}/#{@method}"
       ].join
     end
 

--- a/lib/restapi/resource_description.rb
+++ b/lib/restapi/resource_description.rb
@@ -10,13 +10,14 @@ module Restapi
   # id - resouce name
   class ResourceDescription
     
-    attr_reader :_short_description, :_full_description, :_methods, :_id,
+    attr_reader :controller, :_short_description, :_full_description, :_methods, :_id,
       :_path, :_version, :_name, :_params_ordered
     
-    def initialize(resource_name, &block)
+    def initialize(controller, resource_name, &block)
       @_methods = []
       @_params_ordered = []
 
+      @controller = controller
       @_id = resource_name
       @_version = "1"
       @_name = @_id.humanize
@@ -26,7 +27,7 @@ module Restapi
       
       block.arity < 1 ? instance_eval(&block) : block.call(self) if block_given?
     end
-    
+
     def param(param_name, *args, &block)
       param_description = Restapi::ParamDescription.new(param_name, *args, &block)
       @_params_ordered << param_description
@@ -78,7 +79,5 @@ module Restapi
         :methods => _methods
       }
     end
-
   end
-  
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -50,7 +50,7 @@ describe UsersController do
       a.should eq(b)
 
       a.method.should eq(:show)
-      a.resource.should eq('users')
+      a.resource._id.should eq('users')
       a.errors[0].code.should eq(401)
       a.errors[0].description.should eq("Unauthorized")
       a.errors[1].code.should eq(404)


### PR DESCRIPTION
In case the controllers for API in the app were in submodule, let's say
`Api::UsersController`, there was 'unitialized constant' error when loading
restapi engine. Changing the mechanism for getting a parent so that it works
for this case.
