### PR TITLE
Simplify `api` dsl

### DIFF
--- a/lib/restapi/application.rb
+++ b/lib/restapi/application.rb
@@ -46,8 +46,8 @@ module Restapi
         Restapi::ResourceDescription.new(controller, resource_name, &block)
     end
 
-    def add_method_description_args(args)
-      @last_api_args << MethodDescription::Api.new(args)
+    def add_method_description_args(method, path, desc)
+      @last_api_args << MethodDescription::Api.new(method, path, desc)
     end
     
     # check if there is some saved description

--- a/lib/restapi/dsl_definition.rb
+++ b/lib/restapi/dsl_definition.rb
@@ -23,12 +23,10 @@ module Restapi
     # Declare an api.
     #
     # Example:
-    #   api :desc => "short description",
-    #       :path => "/resource_route",
-    #       :method => "GET"
+    #   api :GET, "/resource_route", "short description",
     #
-    def api(args)
-      Restapi.add_method_description_args(args)
+    def api(method, path, desc = nil)
+      Restapi.add_method_description_args(method, path, desc)
     end
 
     # Describe the next method.

--- a/lib/restapi/method_description.rb
+++ b/lib/restapi/method_description.rb
@@ -7,10 +7,10 @@ module Restapi
       
       attr_accessor :short_description, :api_url, :http_method
       
-      def initialize(args)
-        @http_method = args[:method] || args[:http_method] || args[:http]
-        @short_description = args[:desc] || args[:short] || args[:description]
-        @api_url = create_api_url(args[:path] || args[:url])
+      def initialize(method, path, desc)
+        @http_method = method.to_s
+        @api_url = create_api_url(path)
+        @short_description = desc
       end
       
       private
@@ -74,7 +74,7 @@ module Restapi
       @apis.each.collect do |api|
         {
           :api_url => api.api_url,
-          :http_method => api.http_method,
+          :http_method => api.http_method.to_s,
           :short_description => api.short_description
         }
       end

--- a/spec/dummy/app/controllers/dogs_controller.rb
+++ b/spec/dummy/app/controllers/dogs_controller.rb
@@ -1,8 +1,6 @@
 class DogsController < ApplicationController
   
-  api :desc => "Show dogs profile",
-      :path => "/dogs/:id",
-      :method => "GET"
+  api :GET, "/dogs/:id", "Show dogs profile"
   error :code => 401, :desc => "Unauthorized"
   error :code => 404, :desc => "Not Found"
   desc "+Show dog+ This is *description* of dog show method."
@@ -10,9 +8,7 @@ class DogsController < ApplicationController
     render :nothing => true
   end
 
-  api :desc => "List all dogs",
-      :path => "/dogs",
-      :method => "GET"
+  api :GET, "/dogs", "List all dogs"
   desc "List all dogs which are registered on our social site."
   def index
     render :text => "List of dogs"

--- a/spec/dummy/app/controllers/twitter_example_controller.rb
+++ b/spec/dummy/app/controllers/twitter_example_controller.rb
@@ -6,9 +6,7 @@ class TwitterExampleController < ApplicationController
     path '/users/'
   end
   
-  api :desc => 'Return up to 100 users worth of extended information, specified by either ID, screen name, or combination of the two.',
-      :path => '/users/lookup',
-      :method => 'GET'
+  api :GET, '/users/lookup', 'Return up to 100 users worth of extended information, specified by either ID, screen name, or combination of the two.'
   param :screen_name, String, :desc => 'A comma separated list of screen names, up to 100 are allowed in a single request. You are strongly encouraged to use a POST for larger (up to 100 screen names) requests.'
   param :user_id, Integer, :desc => 'A comma separated list of user IDs, up to 100 are allowed in a single request. You are strongly encouraged to use a POST for larger requests.'
   param :include_entities, String, :desc => 'When set to either <code>true</code>, <code>t</code> or <code>1</code>, each tweet will include a node called "entities,". This node offers a variety of metadata about the tweet in a discreet structure, including: user_mentions, urls, and hashtags. While entities are opt-in on timelines at present, they will be made a default component of output in the future. See Tweet Entities for more detail on entities.'
@@ -30,9 +28,7 @@ class TwitterExampleController < ApplicationController
     render :text => "lookup"
   end
   
-  api :desc => 'Access the profile image in various sizes for the user with the indicated screen_name.',
-      :path => '/users/profile_image/:screen_name',
-      :method => 'GET'
+  api :GET, '/users/profile_image/:screen_name', 'Access the profile image in various sizes for the user with the indicated screen_name.'
   param :screen_name, String, :required => true, :desc => 'The screen name of the user for whom to return results for. Helpful for disambiguating when a valid screen name is also a user ID.'
   param :size, ['bigger','normal','mini','original'], :desc => <<-EOS
     Specifies the size of image to fetch. Not specifying a size will give the default, normal size of 48px by 48px. Valid options include:
@@ -53,8 +49,7 @@ class TwitterExampleController < ApplicationController
     render :text => "profile_image"
   end
   
-  api :path => '/users/search', :method => 'GET',
-      :desc => 'Runs a search for users similar to Find People button on Twitter.com.'
+  api :GET, '/users/search', 'Runs a search for users similar to Find People button on Twitter.com.'
   param :q, String, :desc => 'The search query to run against people search.', :required => true
   param :page, Integer, :desc => 'Specifies the page of results to retrieve.'
   param :per_page, Integer, :desc => 'The number of people to retrieve. Maxiumum of 20 allowed per page.'
@@ -151,8 +146,7 @@ class TwitterExampleController < ApplicationController
     render :text => 'search'
   end
   
-  api :path => '/users/show', :method => 'GET',
-      :desc => 'Returns extended information of a given user, specified by ID or screen name as per the required id parameter.'
+  api :GET, '/users/show', 'Returns extended information of a given user, specified by ID or screen name as per the required id parameter.'
   param :user_id, Integer, :required => true, :desc => <<-EOS
     The ID of the user for whom to return results for. Either an id or screen_name is required for this method.
     _Note_: Specifies the ID of the user to befriend. Helpful for disambiguating when a valid user ID is also a valid screen name.
@@ -169,8 +163,7 @@ class TwitterExampleController < ApplicationController
     render :text => 'show'
   end
   
-  api :path => '/users/contributors', :method => 'GET',
-      :description => 'Returns an array of users who can contribute to the specified account.'
+  api :GET, '/users/contributors', 'Returns an array of users who can contribute to the specified account.'
   param :user_id, Integer, :desc => 'The ID of the user for whom to return results for. Helpful for disambiguating when a valid user ID is also a valid screen name.'
   param :screen_name, String, :desc => 'The screen name of the user for whom to return results for. Helpful for disambiguating when a valid screen name is also a user ID.'
   param :include_entities, String

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -36,9 +36,7 @@ class UsersController < ApplicationController
     EOS
   end
   
-  api :short => "Show user profile",
-      :path => "/users/:id",
-      :method => "GET"
+  api :GET, "/users/:id", "Show user profile"
   error :code => 401, :desc => "Unauthorized"
   error :code => 404, :desc => "Not Found"
   param :id, Fixnum, :desc => "user id", :required => true
@@ -190,7 +188,7 @@ class UsersController < ApplicationController
     render :text => "OK"
   end
   
-  api :desc => "Create user", :path => "/users", :method => "POST"
+  api :POST, "/users", "Create user"
   param :user, Hash, :desc => "User info" do
     param :username, String, :desc => "Username for login", :required => true
     param :password, String, :desc => "Password for login", :required => true
@@ -201,9 +199,7 @@ class UsersController < ApplicationController
     render :text => "OK"
   end
 
-  api :desc => "List users",
-      :path => "/users",
-      :method => "GET"
+  api :GET, "/users", "List users"
   error :code => 401, :desc => "Unauthorized"
   error :code => 404, :desc => "Not Found"
   desc "List all users."
@@ -213,12 +209,8 @@ class UsersController < ApplicationController
     render :text => "List of users"
   end
 
-  api :desc => 'Get company users',
-      :path => '/company_users',
-      :method => 'GET'
-  api :desc => 'Get users working in given company',
-      :path => '/company/:id/users',
-      :method => 'GET'
+  api :GET, '/company_users', 'Get company users'
+  api :GET, '/company/:id/users', 'Get users working in given company'
   param :id, Integer, :desc => "Company ID"
   def two_urls
     render :text => 'List of users'


### PR DESCRIPTION
Less characters needed to define api call since its very frequent call and
there are no so many options to specify.

So instead of

```
 api :method => "GET", :path => "/users", :desc => "List users"
```

one can write

```
 api :GET, "/users", "List users"
```
