### PR TITLE
don't typecast arguments implicitly

### DIFF
--- a/lib/restapi/validator.rb
+++ b/lib/restapi/validator.rb
@@ -62,11 +62,7 @@ module Restapi
 
       def validate(value)
         return false if value.nil?
-        begin
-          Kernel.send(@type.to_s, value)
-        rescue ArgumentError
-          return false
-        end
+        value.is_a? @type
       end
 
       def self.build(param_description, argument, options, block)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -68,12 +68,6 @@ describe UsersController do
       param.validator.class.should be(Restapi::Validator::TypeValidator)
       param.validator.instance_variable_get("@type").should eq(String)
       
-      param = a.params[:float_param]
-      param.required.should eq(false)
-      param.desc.should eq("\n<p>float param</p>\n")
-      param.validator.class.should be(Restapi::Validator::TypeValidator)
-      param.validator.instance_variable_get("@type").should eq(Float)
-
       param = a.params[:id]
       param.required.should eq(true)
       param.desc.should eq("\n<p>user id</p>\n")
@@ -106,29 +100,6 @@ describe UsersController do
             :id => "not a number", 
             :session => "secret_hash"
       }.should raise_error(ArgumentError)
-    end
-    
-    it "should yell ArgumentError if float_param is not a float" do
-      lambda { 
-        get :show, 
-            :id => 5,
-            :session => "secret_hash",
-            :float_param => "234.2.34"
-      }.should raise_error(ArgumentError)
-      
-      lambda { 
-        get :show, 
-            :id => 5, 
-            :session => "secret_hash", 
-            :float_param => "no float here"
-      }.should raise_error(ArgumentError)
-    end
-
-    it "should understand float validator" do
-      get :show, :id => 5, :session => "secret_hash", :float_param => "234.34"
-      assert_response :success
-      get :show, :id => 5, :session => "secret_hash", :float_param => "234"
-      assert_response :success
     end
     
     it "should understand regexp validator" do

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -44,7 +44,6 @@ class UsersController < ApplicationController
   param :id, Fixnum, :desc => "user id", :required => true
   param :id, Integer, :desc => "user id", :required => true
   param :session, String, :desc => "user is logged in", :required => true
-  param :float_param, Float, :desc => "float param"
   param :regexp_param, /^[0-9]* years/, :desc => "regexp param"
   param :array_param, [100, "one", "two", 1, 2], :desc => "array validator"
   param :boolean_param, [true, false], :desc => "array validator with boolean"


### PR DESCRIPTION
If I specify the I expect Float I might be not happy with string "1.1". It's
possible to use RegexpValidator instead. The typecasting also might cause
problems (it works only for some types).
