### PR TITLE
allow nil option

### DIFF
--- a/app/public/restapi/javascripts/jst.js
+++ b/app/public/restapi/javascripts/jst.js
@@ -64,7 +64,7 @@ Restapi.Templates.Resource = _.template(
                 <tbody> \
                   <% _.each(m.params, function(val) { %> \
                     <tr><td><strong><%= val.name %></strong><br>\
-                    <small><%= val.required ? 'required' : 'optional' %></small></td> \
+                    <small><%= val.required ? 'required' : 'optional' %><%= val.allow_nil ? ', nil allowed' : '' %></small></td> \
                     <td><%= val.description %><br>\
                     <% if(val.validator != ''){ %> Value: <%= val.validator %><% } %> \
                     </td></tr> \
@@ -113,7 +113,7 @@ Restapi.Templates.Method = _.template(
           <tr> \
             <td> \
               <strong><%= val.name %></strong><br> \
-              <small><%= val.required ? 'required' : 'optional' %></small> \
+              <small><%= val.required ? 'required' : 'optional' %><%= val.allow_nil ? ', nil allowed' : '' %></small> \
             </td> \
             <td> \
               <%= val.description %><br>\

--- a/lib/restapi/param_description.rb
+++ b/lib/restapi/param_description.rb
@@ -8,7 +8,7 @@ module Restapi
   # validator - Validator::BaseValidator subclass
   class ParamDescription
 
-    attr_reader :name, :desc, :required, :validator
+    attr_reader :name, :desc, :required, :allow_nil, :validator
 
     attr_accessor :parent
     
@@ -24,6 +24,7 @@ module Restapi
       @name = name
       @desc = Restapi.markup_to_html(options[:desc] || '')
       @required = options[:required] || false
+      @allow_nil = options[:allow_nil] || false
       
       @validator = nil
       unless validator_type.nil?
@@ -34,6 +35,7 @@ module Restapi
     end
 
     def validate(value)
+      return true if @allow_nil && value.nil?
       unless @validator.valid?(value)
         raise ArgumentError.new(@validator.error)
       end
@@ -63,6 +65,7 @@ module Restapi
           :name => full_name,
           :description => desc,
           :required => required,
+          :allow_nil => allow_nil,
           :validator => validator.to_s
         }
       end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -201,11 +201,23 @@ describe UsersController do
 
     end
 
-    it "it should support Hash validator without specifying keys" do
+    it "should support Hash validator without specifying keys" do
       Restapi[UsersController, :create].to_json[:params].should include(:name => "facts",
                                                                         :validator => "Parameter has to be Hash.",
                                                                         :description => "\n<p>Additional optional facts about the user</p>\n",
-                                                                        :required => false)
+                                                                        :required => false,
+                                                                        :allow_nil => true)
+    end
+
+    it "should allow nil as the facts argument" do
+      post :create,
+           :user => { 
+             :username => "root",
+             :password => "12345",
+             :membership => "standard",
+           },
+           :facts => nil
+      assert_response :success
     end
 
   end
@@ -234,17 +246,21 @@ describe UsersController do
         :doc_url => "#{Restapi.configuration.doc_base_url}#users/two_urls",
         :full_description => '',
         :params => [{:required=>false,
+                     :allow_nil => false,
                      :validator=>"Parameter has to be String.",
                      :description=>"\n<p>Authorization</p>\n", :name=>"oauth"},
                     {:required=>true,
+                     :allow_nil => false,
                      :validator=>"Parameter has to be String.",
                      :description=>"\n<p>Username for login</p>\n",
                      :name=>"resource_param[username]"},
                     {:required=>true,
+                     :allow_nil => false,
                      :validator=>"Parameter has to be String.",
                      :description=>"\n<p>Password for login</p>\n",
                      :name=>"resource_param[password]"},
                     {:required=>false, :validator=>"Parameter has to be Integer.",
+                     :allow_nil => false,
                      :description=>"\n<p>Company ID</p>\n",
                      :name=>"id"},
        ],

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -193,7 +193,7 @@ class UsersController < ApplicationController
     param :password, String, :desc => "Password for login", :required => true
     param :membership, ["standard","premium"], :desc => "User membership"
   end
-  param :facts, Hash, :desc => "Additional optional facts about the user"
+  param :facts, Hash, :desc => "Additional optional facts about the user", :allow_nil => true
   def create
     render :text => "OK"
   end


### PR DESCRIPTION
Lets parameter to be validated but still allowing it to be nil, e.g.

```
 param :description, String, :allow_nil => true
```

allows sendning {"description": null} with the request
