### PR TITLE
reload controllers in development environment when showing api doc

### DIFF
--- a/app/controllers/restapi/restapis_controller.rb
+++ b/app/controllers/restapi/restapis_controller.rb
@@ -7,7 +7,11 @@ module Restapi
         format.json do
           render :json => Restapi.to_json(params[:resource], params[:method])
         end
-        format.html
+        format.html do
+          if Rails.env.development?
+            Dir[File.join(Rails.root, "app", "controllers", "**","*")].each {|f| load f}
+          end
+        end
       end
     end
 

--- a/lib/restapi/dsl_definition.rb
+++ b/lib/restapi/dsl_definition.rb
@@ -17,6 +17,7 @@ module Restapi
     #   Long description...
     # EOS
     def resource_description(options = {}, &block)
+      Restapi.remove_resource_description(self)
       Restapi.define_resource_description(self, &block) if block_given?
     end
 


### PR DESCRIPTION
It allows instant reload of documentation content. It reloads all the
controllers only when loading the html part (not JSON), so that it's slowed
down only when refreshing the whole page and not on subsequent JSON calls.

It would be better to make this feature customizable by some setting, but for
now lets keep it stupid and simple: it's turned on only in development
environment.
