### PR TITLE
add configuration options for reloading controllers

### DIFF
--- a/app/controllers/restapi/restapis_controller.rb
+++ b/app/controllers/restapi/restapis_controller.rb
@@ -4,13 +4,9 @@ module Restapi
     
     def index
       respond_to do |format|
-
+       
+        Restapi.reload_documentation if Restapi.configuration.reload_controllers?
         @doc = Restapi.to_json(params[:resource], params[:method])
-
-        if (@doc[:docs][:resources].blank? || @doc[:docs][:resources].first == 'null') && Rails.env.development?
-          Dir[File.join(Rails.root, "app", "controllers", "**","*.rb")].each {|f| load f}
-          @doc = Restapi.to_json(params[:resource], params[:method])
-        end
 
         format.json do
           render :json => @doc

--- a/lib/restapi/application.rb
+++ b/lib/restapi/application.rb
@@ -157,6 +157,10 @@ module Restapi
       }
     end
 
+    def reload_documentation
+      Dir[Restapi.configuration.api_controllers_matcher].each {|f|  load f}
+    end
+
     private
 
       def get_resource_name(klass)

--- a/lib/restapi/restapi_module.rb
+++ b/lib/restapi/restapi_module.rb
@@ -28,6 +28,21 @@ module Restapi
   class Configuration
     attr_accessor :app_name, :app_info, :copyright, :markup,
       :validate, :api_base_url, :doc_base_url
+
+    # matcher to be used in Dir.glob to find controllers to be reloaded e.g.
+    #
+    #   "#{Rails.root}/app/controllers/api/*.rb"
+    attr_accessor :api_controllers_matcher
+
+    # set to true if you want to reload the controllers at each refresh of the
+    # documentation. It requires +:api_controllers_matcher+ to be set to work
+    # properly.
+    attr_writer :reload_controllers
+
+    def reload_controllers?
+      @reload_controllers = Rails.env.development? unless defined? @reload_controllers
+      return @reload_controllers && @api_controllers_matcher
+    end
     
     def app_info
       Restapi.markup_to_html(@app_info)

--- a/spec/controllers/restapis_controller_spec.rb
+++ b/spec/controllers/restapis_controller_spec.rb
@@ -9,5 +9,89 @@ describe Restapi::RestapisController do
 
       assert_response :success
     end
+
+  end
+
+  describe "reload_controllers" do
+
+    RSpec::Matchers.define :reload_documentation do
+      match do
+        begin
+          orig = Restapi.get_resource_description("users")._short_description.dup
+          Restapi.get_resource_description("users")._short_description << 'Modified'
+          get :index
+          ret = Restapi.get_resource_description("users")._short_description == orig
+        ensure
+          Restapi.get_resource_description("users")._short_description.gsub!('Modified', "")
+        end
+      end
+
+      failure_message_for_should { "the documentation expected to be reloaded but it was not" }
+      failure_message_for_should_not { "the documentation expected not to be reloaded but it was" }
+    end
+
+    before do
+      Restapi.configuration.api_controllers_matcher = File.join(Rails.root, "app", "controllers", "**","*.rb")
+      if Restapi.configuration.send :instance_variable_defined?, "@reload_controllers"
+        Restapi.configuration.send :remove_instance_variable, "@reload_controllers"
+      end
+    end
+
+    context "it's not specified explicitly" do
+      context "and it's in development environment" do
+        before do
+          Rails.stub(:env => mock(:development? => true))
+        end
+        it { should reload_documentation }
+      end
+
+      context "and it's not development environment" do
+        it { should_not reload_documentation }
+      end
+    end
+
+
+    context "it's explicitly enabled" do
+      before do
+        Restapi.configuration.reload_controllers = true
+      end
+
+      context "and it's in development environment" do
+        before do
+          Rails.stub(:env => mock(:development? => true))
+        end
+        it { should reload_documentation }
+      end
+
+      context "and it's not development environment" do
+        it { should reload_documentation }
+      end
+    end
+
+    context "it's explicitly enabled" do
+      before do
+        Restapi.configuration.reload_controllers = false
+      end
+
+      context "and it's in development environment" do
+        before do
+          Rails.stub(:env => mock(:development? => true))
+        end
+        it { should_not reload_documentation }
+      end
+
+      context "and it's not development environment" do
+        it { should_not reload_documentation }
+      end
+    end
+
+    context "api_controllers_matcher is specified" do
+      before do
+        Restapi.configuration.reload_controllers = true
+        Restapi.configuration.api_controllers_matcher = nil
+      end
+
+      it { should_not reload_documentation }
+    end
   end
 end

--- a/spec/dummy/config/initializers/restapi.rb
+++ b/spec/dummy/config/initializers/restapi.rb
@@ -3,13 +3,22 @@ Restapi.configure do |config|
   config.copyright = "&copy; 2012 Pavel Pokorny"
   config.doc_base_url = "/apidoc"
   config.api_base_url = "/api"
+
+  # set to enable/disable reloading controllers (and the documentation with it),
+  # by default enabled in development
+  # config.reload_controllers = false
+
+  # for reloading to work properly you need to specify where your api controllers are (like in Dir.glob):
+  # config.api_controllers_matcher = File.join(Rails.root, "app", "controllers", "**","*.rb")
+
+  # config.api_base_url = "/api"
   # config.markup = choose one of:
   #   Restapi::Markup::RDoc.new [default]
   #   Restapi::Markup::Markdown.new
   #   Restapi::Markup::Textile.new
   # or provide another class with to_html(text) instance method
   # config.validate = false
-  
+
   path = File.expand_path(File.dirname(__FILE__)+'/../../../../README.rdoc')
   config.app_info = File.read(path)
 end


### PR DESCRIPTION
Two new options added to the configuration:
- reload_controllers [true|false] - if not specified, enabled by default in development
- api_controllers_matcher - Dir.glob like pattern for finding controllers to
  be reloaded. If not specified reloading does not work.
