### PR TITLE
static pages generator improvements

### DIFF
--- a/app/views/layouts/restapi/restapi.html.erb
+++ b/app/views/layouts/restapi/restapi.html.erb
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>API documentation</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
   <% %w[bundled/bootstrap.min.css 
         application.css
         bundled/prettify.css

--- a/app/views/restapi/restapis/index.html.erb
+++ b/app/views/restapi/restapis/index.html.erb
@@ -1,5 +1,5 @@
 <ul class='breadcrumb'>
-  <li class='active'><a href='<%= @doc[:doc_url] %>'><%= @doc[:name] %></a></li>
+  <li class='active'><a href='<%= @doc[:doc_url] %>.html'><%= @doc[:name] %></a></li>
 </ul>
 
 <div><%= @doc[:info].html_safe %></div>
@@ -8,7 +8,7 @@
 
 <% @doc[:resources].each do |key, api| %>
   <h2>
-    <a href='<%= api[:doc_url] %>'><%= api[:name] %></a><br>
+    <a href='<%= api[:doc_url] %>.html'><%= api[:name] %></a><br>
     <small><%= api[:short_description] %></small>
   </h2>
   <table class='table'>
@@ -22,7 +22,7 @@
       <% api[:methods].each do |m| %>
         <% m[:apis].each do |a| %>
           <tr>
-            <td><a href='<%= m[:doc_url] %>'><%= a[:http_method] %> <%= a[:api_url] %></a></td>
+            <td><a href='<%= m[:doc_url] %>.html'><%= a[:http_method] %> <%= a[:api_url] %></a></td>
             <td width='60%'><%= a[:short_description] %></td>
           </tr>
         <% end %>

--- a/app/views/restapi/restapis/method.html.erb
+++ b/app/views/restapi/restapis/method.html.erb
@@ -1,10 +1,10 @@
 <ul class='breadcrumb'>
   <li>
-    <a href='<%= @doc[:doc_url] %>'><%= @doc[:name] %></a>
+    <a href='<%= @doc[:doc_url] %>.html'><%= @doc[:name] %></a>
     <span class='divider'>/</span>
   </li>
   <li>
-    <a href='<%= @resource[:doc_url] %>'><%= @resource[:name] %></a>
+    <a href='<%= @resource[:doc_url] %>.html'><%= @resource[:name] %></a>
     <span class='divider'>/</span>
   </li>
   <li class='active'><%= @method[:name] %></li>

--- a/app/views/restapi/restapis/resource.html.erb
+++ b/app/views/restapi/restapis/resource.html.erb
@@ -1,5 +1,5 @@
 <ul class='breadcrumb'>
-  <li><a href='<%= @doc[:doc_url] %>'><%= @doc[:name] %></a><span class='divider'>/</span></li>
+  <li><a href='<%= @doc[:doc_url] %>.html'><%= @doc[:name] %></a><span class='divider'>/</span></li>
   <li class='active'><%= @resource[:name] %></li>
 </ul>
 
@@ -20,7 +20,7 @@
   <% @resource[:methods].each do |m| %>
     <hr>
     <div class='pull-right small'>
-      <a href='<%= m[:doc_url] %>'> >>> </a>
+      <a href='<%= m[:doc_url] %>.html'> >>> </a>
     </div>
     <div>
       <% m[:apis].each do |api| %>

--- a/app/views/restapi/restapis/static.html.erb
+++ b/app/views/restapi/restapis/static.html.erb
@@ -1,5 +1,3 @@
-<% @doc = doc %>
-
 <% @doc[:resources].each do |key, resource| %>
   <h4><a href='#<%= key %>'><%= resource[:name] %></a></h4>
   <ul>

--- a/lib/restapi/application.rb
+++ b/lib/restapi/application.rb
@@ -166,7 +166,7 @@ module Restapi
           :name => Restapi.configuration.app_name,
           :info => Restapi.configuration.app_info,
           :copyright => Restapi.configuration.copyright,
-          :doc_url => "#{ENV["RAILS_RELATIVE_URL_ROOT"]}#{Restapi.configuration.doc_base_url}",
+          :doc_url => Restapi.full_url(""),
           :api_url => Restapi.configuration.api_base_url,
           :resources => _resources
         }

--- a/lib/restapi/helpers.rb
+++ b/lib/restapi/helpers.rb
@@ -4,16 +4,21 @@ module Restapi
       Restapi.configuration.markup.to_html(text.strip_heredoc)
     end
 
+    attr_accessor :url_prefix
+
     def full_url(path)
-      unless @prefix
-        @prefix = ""
+      unless @url_prefix
+        @url_prefix = ""
         if rails_prefix = ENV["RAILS_RELATIVE_URL_ROOT"]
-          @prefix << rails_prefix
+          @url_prefix << rails_prefix
         end
-        @prefix << Restapi.configuration.doc_base_url
+        @url_prefix << Restapi.configuration.doc_base_url
       end
       path = path.sub(/^\//,"")
-      "#{@prefix}/#{path}"
+      ret = "#{@url_prefix}/#{path}"
+      ret.insert(0,"/") unless ret =~ /\A[.\/]/
+      ret.sub!(/\/*\Z/,"")
+      ret
     end
   end
 end

--- a/lib/restapi/method_description.rb
+++ b/lib/restapi/method_description.rb
@@ -70,11 +70,7 @@ module Restapi
     end
     
     def doc_url
-      [
-        ENV["RAILS_RELATIVE_URL_ROOT"],
-        Restapi.configuration.doc_base_url,
-        "/#{@resource._id}/#{@method}"
-      ].join
+      Restapi.full_url("#{@resource._id}/#{@method}")
     end
 
     def method_apis_to_json

--- a/lib/restapi/resource_description.rb
+++ b/lib/restapi/resource_description.rb
@@ -56,7 +56,7 @@ module Restapi
     end
     
     def doc_url
-      "#{ENV["RAILS_RELATIVE_URL_ROOT"]}#{Restapi.configuration.doc_base_url}/#{@_id}"
+      Restapi.full_url(@_id)
     end
 
     def api_url; "#{Restapi.configuration.api_base_url}#{@_path}"; end


### PR DESCRIPTION
rake restapi:static is now able to generate both onepage and hierarchical
pages (looking exactly the same like the online version).

You can specify the output path for the generated documentation using OUT env
variable ("#{Rails.root}/doc/apidoc").

You will end up with a file hierarchy looking something like this:

```
apidoc.html
apidoc-onepage.html
apidoc
| - resource1.html
| - resource1
| - | - method1.html
| - | - method2.html
| - resource2.html
```
