### PR TITLE
production mode

### DIFF
--- a/lib/restapi/application.rb
+++ b/lib/restapi/application.rb
@@ -178,6 +178,13 @@ module Restapi
       Dir[Restapi.configuration.api_controllers_matcher].each {|f|  load f}
     end
 
+    # Is there a reason to interpret the DSL for this run?
+    # with specific setting for some environment there is no reason the dsl
+    # should be interpreted (e.g. no validations and doc from cache)
+    def active_dsl?
+      Restapi.configuration.validate? || ! Restapi.configuration.use_cache?
+    end
+
     private
 
       def get_resource_name(klass)

--- a/lib/restapi/dsl_definition.rb
+++ b/lib/restapi/dsl_definition.rb
@@ -16,6 +16,7 @@ module Restapi
     #   Long description...
     # EOS
     def resource_description(options = {}, &block) #:doc:
+      return unless Restapi.active_dsl?
       Restapi.remove_resource_description(self)
       Restapi.define_resource_description(self, &block) if block_given?
     end
@@ -26,6 +27,7 @@ module Restapi
     #   api :GET, "/resource_route", "short description",
     #
     def api(method, path, desc = nil) #:doc:
+      return unless Restapi.active_dsl?
       Restapi.add_method_description_args(method, path, desc)
     end
 
@@ -38,6 +40,7 @@ module Restapi
     #   end
     #
     def desc(description) #:doc:
+      return unless Restapi.active_dsl?
       if Restapi.last_description
         raise "Double method description."
       end
@@ -48,6 +51,7 @@ module Restapi
     # Show some example of what does the described
     # method return.
     def example(example) #:doc:
+      return unless Restapi.active_dsl?
       Restapi.add_example(example)
     end
 
@@ -61,6 +65,7 @@ module Restapi
     #   end
     #
     def error(args) #:doc:
+      return unless Restapi.active_dsl?
       Restapi.last_errors << Restapi::ErrorDescription.new(args)
     end
 
@@ -73,14 +78,15 @@ module Restapi
     #   end
     #
     def param(param_name, *args, &block) #:doc:
+      return unless Restapi.active_dsl?
       Restapi.last_params << Restapi::ParamDescription.new(param_name, *args, &block)
     end
 
     # create method api and redefine newly added method
     def method_added(method_name) #:doc:
-
       super
 
+      return unless Restapi.active_dsl?
       return unless Restapi.restapi_provided?
 
       # remove method description if exists and create new one

--- a/lib/restapi/restapi_module.rb
+++ b/lib/restapi/restapi_module.rb
@@ -29,6 +29,8 @@ module Restapi
     attr_accessor :app_name, :app_info, :copyright, :markup,
       :validate, :api_base_url, :doc_base_url
 
+    alias_method :validate?, :validate
+
     # matcher to be used in Dir.glob to find controllers to be reloaded e.g.
     #
     #   "#{Rails.root}/app/controllers/api/*.rb"
@@ -42,6 +44,21 @@ module Restapi
     def reload_controllers?
       @reload_controllers = Rails.env.development? unless defined? @reload_controllers
       return @reload_controllers && @api_controllers_matcher
+    end
+
+    # set to true if you want to use pregenerated documentation cache and avoid
+    # generating the documentation on runtime (usefull for production
+    # environment).
+    # You can generate the cache by running
+    #
+    #     rake restapi:cache
+    attr_accessor :use_cache
+    alias_method :use_cache?, :use_cache
+
+    attr_writer :cache_dir
+
+    def cache_dir
+      @cache_dir ||= File.join(Rails.root, "public", "restapi-cache")
     end
     
     def app_info

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -318,8 +318,7 @@ describe UsersController do
 GET /users/14?verbose=true
 200
 {
-  "name": "Test User",
-  "id": 14
+  "name": "Test User"
 }
 EOS1
 GET /users/15

--- a/spec/dummy/config/initializers/restapi.rb
+++ b/spec/dummy/config/initializers/restapi.rb
@@ -4,6 +4,13 @@ Restapi.configure do |config|
   config.doc_base_url = "/apidoc"
   config.api_base_url = "/api"
 
+  # set to true to turn on/off the cache. To generate the cache use:
+  #
+  #     rake restapi:cache
+  #
+  # config.use_cache = Rails.env.production?
+  # config.cache_dir = File.join(Rails.root, "public", "restapi-cache") # optional
+
   # set to enable/disable reloading controllers (and the documentation with it),
   # by default enabled in development
   # config.reload_controllers = false

--- a/spec/dummy/doc/restapi_examples.yml
+++ b/spec/dummy/doc/restapi_examples.yml
@@ -13,7 +13,6 @@ users#show:
   query: "verbose=true"
   request_data: 
   response_data: 
-    id: 14
     name: Test User
   code: 200
   show_in_doc: 1
@@ -23,7 +22,6 @@ users#show:
   query: "verbose=true"
   request_data: 
   response_data: 
-    id: 14
     name: Test User
   code: 200
   show_in_doc: 0


### PR DESCRIPTION
It allows to pre-generate cache (both html and json files) that can be severed
instead for generating the documentation on runtime. This means that on
production machines you can avoid all the doc-rendering dependencies but still
use the same API both for html and json format.

To use the cache you need to set:

```
use_cache = true
```

It also allows you to se the cache dir (public/restapi-cache by default)

```
cache_dir = File.join(Rails.root, "tmp", "restapi-cache")
```

To generate the cache, run (it won't work without it):

   rake restapi:cache

Last but not least, if you use the cache with validations turned off, the
runtime won't be affected by the documentation at all. This is good in
case you're not sure if it could have some impact on you production
environment: in this mode it won't have any. But you can still documentation
generating at runtime for development environment or validations for running
tests.

It also should fix the failing tests from the exampels.yml pull request.
