### PR TITLE
security fix: using cache might expose files from the file system

### DIFF
--- a/app/controllers/restapi/restapis_controller.rb
+++ b/app/controllers/restapi/restapis_controller.rb
@@ -7,6 +7,10 @@ module Restapi
 
         if Restapi.configuration.use_cache?
           path = Restapi.configuration.doc_base_url.dup
+          if [:resource, :method, :format].any? { |p| params[p].to_s =~ /\W/ }
+            head :bad_request and return
+          end
+
           path << "/" << params[:resource] if params[:resource].present?
           path << "/" << params[:method] if params[:method].present?
           if params[:format].present?


### PR DESCRIPTION
Due to request params not being sanitized it was possible to request any file
from file system when using appropriate path, e.g.:

```
/apidoc?resource=../../../config/database&format=yml
```

The fix sanitizes all the params used for producing the file to be sent.
