### PR TITLE
Fix superclass mismatch problem when reloading controllers

### DIFF
--- a/lib/restapi/application.rb
+++ b/lib/restapi/application.rb
@@ -173,9 +173,15 @@ module Restapi
       }
     end
 
+    def api_controllers_paths
+      Dir[Restapi.configuration.api_controllers_matcher]
+    end
+
     def reload_documentation
       reload_examples
-      Dir[Restapi.configuration.api_controllers_matcher].each {|f|  load f}
+      api_controllers_paths.each do |f|
+        load_controller_from_file f
+      end
     end
 
     # Is there a reason to interpret the DSL for this run?
@@ -187,13 +193,18 @@ module Restapi
 
     private
 
-      def get_resource_name(klass)
-        if klass.class == String
-          klass
-        elsif klass.class == Class && ActionController::Base.descendants.include?(klass)
-          klass.controller_name
-        end
+    def get_resource_name(klass)
+      if klass.class == String
+        klass
+      elsif klass.class == Class && ActionController::Base.descendants.include?(klass)
+        klass.controller_name
       end
+    end
+
+    def load_controller_from_file(controller_file)
+      controller_class_name = controller_file.gsub(/\A.*\/app\/controllers\//,"").gsub(/\.\w*\Z/,"").camelize
+      controller_class_name.constantize
+    end
 
   end
 end

--- a/spec/controllers/restapis_controller_spec.rb
+++ b/spec/controllers/restapis_controller_spec.rb
@@ -17,13 +17,12 @@ describe Restapi::RestapisController do
 
     RSpec::Matchers.define :reload_documentation do
       match do
+        Restapi.should_receive(:reload_documentation)
+        get :index
         begin
-          orig = Restapi.get_resource_description("users")._short_description.dup
-          Restapi.get_resource_description("users")._short_description << 'Modified'
-          get :index
-          ret = Restapi.get_resource_description("users")._short_description == orig
-        ensure
-          Restapi.get_resource_description("users")._short_description.gsub!('Modified', "")
+          RSpec::Mocks.verify
+        rescue RSpec::Mocks::MockExpectationError
+          false
         end
       end
 


### PR DESCRIPTION
Let Rails and it's autoload feature to load and unload the controllers.

The original solution was still causing class mismatch problems in some cases.
