### PR TITLE
rails 3.2 compatibility

### DIFF
--- a/lib/restapi/application.rb
+++ b/lib/restapi/application.rb
@@ -211,11 +211,7 @@ module Restapi
     def get_resource_name(klass)
       if klass.class == String
         klass
-      elsif klass.class == Class &&
-        (
-          ActionController::Base.descendants.include?(klass) ||
-          (defined?(ActionController::API) && ActionController::API.descendants.include?(klass))
-        )
+      elsif klass.respond_to?(:controller_name)
         klass.controller_name
       end
     end


### PR DESCRIPTION
Fix for getting the following error with Rails 3.2 @ Ruby 1.9.3:

```
undefined method `humanize' for nil:NilClass
lib/restapi/resource_description.rb:23:in `initialize'
```

I was getting this issue with the older version of the code, and it's possible that it was solved in the mean time, but maybe going the way of duck-typing is not the bad way for this issue.
