### PR TITLE
Fix client compatibility issues with Ruby 1.9

### DIFF
--- a/lib/restapi/client/template/cli.rb.tt
+++ b/lib/restapi/client/template/cli.rb.tt
@@ -12,7 +12,7 @@ class <%= resource_name.camelize %> < <%= class_base %>Client::CliCommand
 <%   if params_in_path(method).any? || transformation_hash(method).any?
        transform_options_params = [params_in_path(method).inspect]
        transform_options_params << transformation_hash(method).inspect if transformation_hash(method).any? -%>
-    <%= (params_in_path(method) + ["options"]).join(", ") %> = transform_options(<%= transform_options_params.join(", ").html_safe %>)
+    <%= (params_in_path(method) + ["options"]).join(", ") %>, *_ = transform_options(<%= transform_options_params.join(", ").html_safe %>)
 <%   end
 
   client_args = params_in_path(method).dup


### PR DESCRIPTION
There is a difference in assignment descructuring in 1.8 and 1.9:

```
# in 1.8.7
a = *[1]; a # => 1
# in 1.9.3
a = *[1]; a # => [1]
```

Using

```
a, *_ = [1]; a # => 1
```

works the same for both versions.
