### PR TITLE
Fix custom validator syntax error

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -300,7 +300,7 @@ So we create apipie_validators.rb initializer with this content:
 
       def validate(value)
         return false if value.nil?
-        !!(value.to_s =~ \/^[-+]?[0-9]+$/)
+        !!(value.to_s =~ /^[-+]?[0-9]+$/)
       end
 
       def self.build(param_description, argument, options, block)


### PR DESCRIPTION
Small typo in the README.
