### PR TITLE
DSL enhancement for parameter description

### DIFF
--- a/lib/apipie/dsl_definition.rb
+++ b/lib/apipie/dsl_definition.rb
@@ -97,9 +97,9 @@ module Apipie
     #     puts greeting
     #   end
     #
-    def param(param_name, *args, &block) #:doc:
+    def param(param_name, validator, desc_or_options = nil, options = {}, &block) #:doc:
       return unless Apipie.active_dsl?
-      Apipie.last_params << Apipie::ParamDescription.new(param_name, *args, &block)
+      Apipie.last_params << Apipie::ParamDescription.new(param_name, validator, desc_or_options, options, &block)
     end
 
     # create method api and redefine newly added method

--- a/lib/apipie/param_description.rb
+++ b/lib/apipie/param_description.rb
@@ -12,14 +12,15 @@ module Apipie
 
     attr_accessor :parent
 
-    def initialize(name, *args, &block)
+    def initialize(name, validator, desc_or_options = nil, options = {}, &block)
 
-      if args.size > 1 || !args.first.is_a?(Hash)
-        validator_type = args.shift || nil
-      else
-        validator_type = nil
+      if desc_or_options.is_a?(Hash) && options.empty?
+        options = desc_or_options
+      elsif desc_or_options.is_a?(String)
+        options[:desc] = desc_or_options
+      elsif !desc_or_options.nil?
+        raise ArgumentError.new("param description: expected description or options as 3rd parameter")
       end
-      options = args.pop || {}
 
       @name = name
       @desc = Apipie.markup_to_html(options[:desc] || '')
@@ -27,9 +28,9 @@ module Apipie
       @allow_nil = options[:allow_nil] || false
 
       @validator = nil
-      unless validator_type.nil?
+      unless validator.nil?
         @validator =
-          Validator::BaseValidator.find(self, validator_type, options, block)
+          Validator::BaseValidator.find(self, validator, options, block)
         raise "Validator not found." unless validator
       end
     end

--- a/lib/apipie/resource_description.rb
+++ b/lib/apipie/resource_description.rb
@@ -31,8 +31,8 @@ module Apipie
       block.arity < 1 ? instance_eval(&block) : block.call(self) if block_given?
     end
 
-    def param(param_name, *args, &block)
-      param_description = Apipie::ParamDescription.new(param_name, *args, &block)
+    def param(param_name, validator, desc_or_options = nil, options = {}, &block)
+      param_description = Apipie::ParamDescription.new(param_name, validator, desc_or_options, options, &block)
       @_params_ordered << param_description
     end
 

--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -198,8 +198,8 @@ module Apipie
         "Must be a Hash"
       end
 
-      def param(param_name, *args, &block)
-        param_description = Apipie::ParamDescription.new(param_name, *args, &block)
+      def param(param_name, validator, desc_or_options = nil, options = {}, &block)
+        param_description = Apipie::ParamDescription.new(param_name, validator, desc_or_options, options, &block)
         param_description.parent = self.param_description
         @hash_params_ordered << param_description
         @hash_params[param_name.to_sym] = param_description

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -263,8 +263,8 @@ describe UsersController do
 
     it "should contain all params description" do
       a = Apipie.get_method_description(UsersController, :show)
-      a.params.count.should == 8
-      a.instance_variable_get('@params_ordered').count.should == 6
+      a.params.count.should == 9
+      a.instance_variable_get('@params_ordered').count.should == 7
     end
 
     it "should contain all api method description" do
@@ -394,6 +394,10 @@ EOS2
       param = a.params[:proc_param]
       param.desc.should eq("\n<p>proc validator</p>\n")
       param.validator.class.should be(Apipie::Validator::ProcValidator)
+
+      param = a.params[:briefer_dsl]
+      param.desc.should eq("\n<p>You dont need :desc =&gt; from now</p>\n")
+      param.validator.class.should be(Apipie::Validator::TypeValidator)
     end
 
   end

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -177,6 +177,7 @@ class UsersController < ApplicationController
   param :proc_param, lambda { |val|
     val == "param value" ? true : "The only good value is 'param value'."
   }, :desc => "proc validator"
+  param :briefer_dsl, String, "You dont need :desc => from now"
   def show
     unless params[:session] == "secret_hash"
       render :text => "Not authorized", :status => 401


### PR DESCRIPTION
There are two ways how to specify parameter description now:
param :name, validator, :desc => description
or
param :name, validator, description

Idea introduced in issue #49
