### PR TITLE
Added config.layout for doc pages

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -73,6 +73,7 @@ of full descriptions.
          need RedCloth. Add those to your gemfile and run bundle if you
          want to use them. You can also add any other markup language
          processor.
+[layout] Name of a layout template to use instead of Apipie's layout.  But note you may want to include Apipie's styelsheets and javascript for the interaction to work properly.
 
 Example:
 

--- a/app/controllers/apipie/apipies_controller.rb
+++ b/app/controllers/apipie/apipies_controller.rb
@@ -1,6 +1,6 @@
 module Apipie
   class ApipiesController < ActionController::Base
-    layout 'apipie/apipie'
+    layout Apipie.configuration.layout
 
     def index
       respond_to do |format|

--- a/lib/apipie/apipie_module.rb
+++ b/lib/apipie/apipie_module.rb
@@ -27,7 +27,7 @@ module Apipie
 
   class Configuration
     attr_accessor :app_name, :app_info, :copyright, :markup,
-      :validate, :api_base_url, :doc_base_url
+      :validate, :api_base_url, :doc_base_url, :layout
 
     alias_method :validate?, :validate
 
@@ -99,6 +99,7 @@ module Apipie
       @validate = true
       @api_base_url = ""
       @doc_base_url = "/apipie"
+      @layout = "apipie/apipie"
     end
   end
 


### PR DESCRIPTION
hi again,

i found i wanted to integrate the apipie pages into my application's layout.  so i added another configuration field to set the layout:

```
Apipie.configure do |config|
  ...
  config.layout = 'api'
  ...
end
```

of course it was then incumbent on me to ensure that i included the appropriate css and javascript to make the interaction work.  so i made a wrapper layout for the api docs, which then calls the main application layout.  that is, i have <code>layouts/api.html.haml</code>:

```
- content_for :head do
  - %w[bundled/bootstrap.min.css application.css bundled/prettify.css bundled/bootstrap-responsive.min.css ].each do |file|
    %link{type: "text/css", rel: "stylesheet", href: Apipie.full_url("stylesheets/#{file}")}
- content_for :tail do
  - %w[ bundled/bootstrap-collapse.js bundled/prettify.js apipie.js ].each do |file|
    %script{type: "text/javascript", src: Apipie.full_url("javascripts/#{file}")}
=render :template => "layouts/application"
```

and <code>layouts/application.html.haml</code> has <code>yield :head</code> and <code>yield :tail</code> in the appropriate places.

i cribbed all that stuff from apipie's layout -- but it could be nice instead to bundle them into some convenient helpers.  i didn't want to do that without feedback from you first, though.

so anyway i don't know if you want to pull this as is, or use it as a springboard for some other approach, or ignore it entirely :)  but i figured i'd at least show it to you.

thanks,
-ronen
