### PR TITLE
Make the cache independent from the absolute path

### DIFF
--- a/lib/tasks/apipie.rake
+++ b/lib/tasks/apipie.rake
@@ -40,10 +40,15 @@ namespace :apipie do
   task :cache => :environment do
     with_loaded_documentation do
       cache_dir = Apipie.configuration.cache_dir
+      subdir = Apipie.configuration.doc_base_url.sub(/\A\//,"")
+
       file_base = File.join(cache_dir, Apipie.configuration.doc_base_url)
+      Apipie.url_prefix = "./#{subdir}"
       doc = Apipie.to_json
       generate_index_page(file_base, doc, true)
+      Apipie.url_prefix = "../#{subdir}"
       generate_resource_pages(file_base, doc, true)
+      Apipie.url_prefix = "../../#{subdir}"
       generate_method_pages(file_base, doc, true)
     end
   end


### PR DESCRIPTION
Before this change, the cache was dependent on the full path to the service
(including the path the rails app was mounted, e.g. through
RAILS_RELATEIVE_URL_ROOT).

This made the cache unusable in case the mount point changed. This changes
makes the links from the change relative, fixing the issue with paths.

See https://bugzilla.redhat.com/show_bug.cgi?id=852388#c14 for example of such
an issue.
