### PR TITLE
Use Maruku as default markdown renderer

### DIFF
--- a/apipie-rails.gemspec
+++ b/apipie-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rails", ">= 3.0.10"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "minitest"
-  s.add_development_dependency "redcarpet"
+  s.add_development_dependency "maruku"
   s.add_development_dependency "RedCloth"
   s.add_development_dependency "rake"
   s.add_development_dependency "rest-client"

--- a/lib/apipie/markup.rb
+++ b/lib/apipie/markup.rb
@@ -19,12 +19,11 @@ module Apipie
     class Markdown
 
       def initialize
-        require 'redcarpet'
-        @redcarpet ||= ::Redcarpet::Markdown.new(::Redcarpet::Render::HTML.new)
+        require 'maruku'
       end
 
       def to_html(text)
-        @redcarpet.render(text)
+        Maruku.new(text).to_html
       end
 
     end


### PR DESCRIPTION
Addressing #24 - Redcarpet uses a C extension, that seqfaults on some
systems (observed on Mac OS and RHEL). Using pure Ruby implementation
instead (the performance should not be issue in this use case).
