### PR TITLE
Fix gemspec deps

### DIFF
--- a/apipie-rails.gemspec
+++ b/apipie-rails.gemspec
@@ -16,13 +16,11 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ["lib"]
 
+  s.add_dependency "rails", ">= 3.0.10"
   s.add_development_dependency "rspec-rails"
-  s.add_development_dependency "rails", ">= 3.0.10"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "minitest"
   s.add_development_dependency "maruku"
   s.add_development_dependency "RedCloth"
   s.add_development_dependency "rake"
-  s.add_development_dependency "rest-client"
-  s.add_development_dependency "oauth"
 end


### PR DESCRIPTION
Oauth and rest_client no longer needed, Rails is needed in runtime. Addressing #78 
