### PR TITLE
Use request.env['SCRIPT_NAME'] instead of ENV['RAILS_RELATIVE_URL_ROOT']

### DIFF
--- a/app/controllers/apipie/apipies_controller.rb
+++ b/app/controllers/apipie/apipies_controller.rb
@@ -2,6 +2,8 @@ module Apipie
   class ApipiesController < ActionController::Base
     layout Apipie.configuration.layout
 
+    around_filter :set_script_name
+
     def index
 
       params[:version] ||= Apipie.configuration.default_version
@@ -75,5 +77,11 @@ module Apipie
       end
     end
 
+    def set_script_name
+      Apipie.request_script_name = request.env["SCRIPT_NAME"]
+      yield
+    ensure
+      Apipie.request_script_name = nil
+    end
   end
 end

--- a/lib/apipie/helpers.rb
+++ b/lib/apipie/helpers.rb
@@ -11,12 +11,18 @@ module Apipie
 
     attr_accessor :url_prefix
 
+    def request_script_name
+      Thread.current[:apipie_req_script_name] || ""
+    end
+
+    def request_script_name=(script_name)
+      Thread.current[:apipie_req_script_name] = script_name
+    end
+
     def full_url(path)
       unless @url_prefix
         @url_prefix = ""
-        if rails_prefix = ENV["RAILS_RELATIVE_URL_ROOT"]
-          @url_prefix << rails_prefix
-        end
+        @url_prefix << request_script_name
         @url_prefix << Apipie.configuration.doc_base_url
       end
       path = path.sub(/^\//,"")

--- a/lib/apipie/static_dispatcher.rb
+++ b/lib/apipie/static_dispatcher.rb
@@ -46,7 +46,6 @@ module Apipie
       case env['REQUEST_METHOD']
       when 'GET', 'HEAD'
         path = env['PATH_INFO'].sub("#{@baseurl}/","/apipie/").chomp('/')
-        path.sub!("#{ENV["RAILS_RELATIVE_URL_ROOT"]}",'')
 
         if match = @file_handler.match?(path)
           env["PATH_INFO"] = match


### PR DESCRIPTION
RAILS_RELATIVE_URL_ROOT is deprecated and doesn't have to work with
newer Rails apps
