### PR TITLE
Fix params extractor

### DIFF
--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -281,8 +281,6 @@ module Apipie
       Apipie.configuration.validate? || ! Apipie.configuration.use_cache? || Apipie.configuration.force_dsl?
     end
 
-    private
-
     def get_resource_name(klass)
       if klass.class == String
         klass
@@ -295,6 +293,8 @@ module Apipie
         raise "Apipie: Can not resolve resource #{klass} name."
       end
     end
+
+    private
 
     def get_resource_version(resource_description)
       if resource_description.respond_to? :_version

--- a/lib/apipie/resource_description.rb
+++ b/lib/apipie/resource_description.rb
@@ -64,6 +64,10 @@ module Apipie
       end
     end
 
+    def method_descriptions
+      @_methods.values
+    end
+
     def doc_url
       crumbs = []
       crumbs << _version if Apipie.configuration.version_in_url


### PR DESCRIPTION
Running tests with APIPIE_RECORD=params was failing when there was
already some documentation.
