### PR TITLE
Allow specify additional params outside of param group

### DIFF
--- a/lib/apipie/method_description.rb
+++ b/lib/apipie/method_description.rb
@@ -43,6 +43,7 @@ module Apipie
       @params_ordered = dsl_data[:params].map do |args|
         Apipie::ParamDescription.from_dsl_data(self, args)
       end
+      @params_ordered = ParamDescription.unify(@params_ordered)
     end
 
     def id

--- a/lib/apipie/param_description.rb
+++ b/lib/apipie/param_description.rb
@@ -102,6 +102,35 @@ module Apipie
       end
     end
 
+    def merge_with(other_param_desc)
+      if self.validator && other_param_desc.validator
+        self.validator.merge_with(other_param_desc.validator)
+      else
+        self.validator ||= other_param_desc.validator
+      end
+      self
+    end
+
+    # merge param descripsiont. Allows defining hash params on more places
+    # (e.g. in param_groups). For example:
+    #
+    #     def_param_group :user do
+    #       param :user, Hash do
+    #         param :name, String
+    #       end
+    #     end
+    #
+    #     param_group :user
+    #     param :user, Hash do
+    #       param :password, String
+    #     end
+    def self.unify(params)
+      ordering = params.map(&:name)
+      params.group_by(&:name).map do |name, param_descs|
+        param_descs.reduce(&:merge_with)
+      end.sort_by { |param| ordering.index(param.name) }
+    end
+
   end
 
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -156,7 +156,7 @@ describe UsersController do
         param.count.should == 1
         param.first.validator.class.should eq(Apipie::Validator::HashValidator)
         hash_params = param.first.validator.hash_params_ordered
-        hash_params.count.should == 3
+        hash_params.count.should == 4
         hash_params[0].name == :name
         hash_params[1].name == :pass
         hash_params[2].name == :membership

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -204,6 +204,9 @@ class UsersController < ApplicationController
 
   api :POST, "/users", "Create user"
   param_group :user
+  param :user, Hash do
+    param :permalink, String
+  end
   param :facts, Hash, :desc => "Additional optional facts about the user", :allow_nil => true
   def create
     render :text => "OK #{params.inspect}"

--- a/spec/lib/param_group_spec.rb
+++ b/spec/lib/param_group_spec.rb
@@ -9,13 +9,20 @@ describe "param groups" do
     user_update_desc = Apipie["users#update"].params[:user]
     user_update_params = user_update_desc.validator.hash_params_ordered.map(&:name)
 
-    user_create_params.sort_by(&:to_s).should == user_update_params.sort_by(&:to_s)
+    common = user_update_params & user_create_params
+    common.sort_by(&:to_s).should == user_update_params.sort_by(&:to_s)
   end
 
   it "allows using groups is nested param descriptions" do
-    user_create_desc = Apipie["users#create"].params[:user]
+    user_create_desc = Apipie["users#update"].params[:user]
     user_create_params = user_create_desc.validator.hash_params_ordered.map(&:name)
     user_create_params.map(&:to_s).sort.should == %w[membership name pass]
+  end
+
+  it "should allow adding additional params to group" do
+    user_create_desc = Apipie["users#create"].params[:user]
+    user_create_params = user_create_desc.validator.hash_params_ordered.map(&:name)
+    user_create_params.map(&:to_s).sort.should == %w[membership name pass permalink]
   end
 
   it "lets you reuse a group definition from different controller" do


### PR DESCRIPTION
Especially useful for hash params. For example:

``` ruby
def_param_group :user do
 param :user, Hash do
   param :name, String
 end
end

param_group :user
param :user, Hash do
 param :password, String
end
```
