### PR TITLE
Action Aware params

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -318,6 +318,50 @@ Example:
      # ...
    end
 
+Action Aware params
+-------------------
+
+In CRUD operations, this pattern occurs quite often: params that need
+to be set are:
+
+* for create action: ``required => true`` and ``allow_nil => false``
+* for update action: ``required => false`` and ``allow_nil => false``
+
+This makes it hard to share the param definitions across theses
+actions. Therefore, you can make the description a bit smarter by
+setting ``:action_aware => true``.
+
+Example
+~~~~~~~
+
+.. code:: ruby
+
+   def_param_group :user do
+     param :user, Hash, :action_aware => true do
+       param :name, String, :required => true
+       param :description, :String
+     end
+   end
+
+   api :POST, "/users", "Create an user"
+   param_group :user
+   def create
+     # ...
+   end
+
+   api :PUT, "/users/:id", "Update an user"
+   param_group :user
+   def update
+     # ...
+   end
+
+In this case, ``user[name]`` will be not be allowed nil for both
+actions and required only for create. Params with ``allow_nil`` set
+explicitly don't have this value changed.
+
+Action awareness is being inherited from ancestors (in terms of
+nested params).
+
 
 =========================
  Configuration Reference

--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -190,6 +190,8 @@ module Apipie
 
       def hash_params_ordered
         @hash_params_ordered ||= _apipie_dsl_data[:params].map do |args|
+          options = args.find { |arg| arg.is_a? Hash }
+          options[:parent] = self.param_description
           Apipie::ParamDescription.from_dsl_data(param_description.method_description, args)
         end
       end
@@ -228,7 +230,6 @@ module Apipie
 
       def prepare_hash_params
         @hash_params = hash_params_ordered.reduce({}) do |h, param|
-          param.parent = self.param_description
           h.update(param.name.to_sym => param)
         end
       end

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -196,9 +196,9 @@ class UsersController < ApplicationController
   end
 
   def_param_group :user do
-    param :user, Hash, :desc => "User info", :required => true do
+    param :user, Hash, :desc => "User info", :required => true, :action_aware => true do
       param_group :credentials
-      param :membership, ["standard","premium"], :desc => "User membership"
+      param :membership, ["standard","premium"], :desc => "User membership", :allow_nil => false
     end
   end
 

--- a/spec/lib/param_description_spec.rb
+++ b/spec/lib/param_description_spec.rb
@@ -48,4 +48,54 @@ describe Apipie::ParamDescription do
 
   end
 
+  describe "required params in action aware validator" do
+
+    subject { method_description.params[:user].validator.hash_params_ordered }
+
+    let(:required) do
+      subject.find_all(&:required).map(&:name)
+    end
+
+    let(:allowed_nil) do
+      subject.find_all(&:allow_nil).map(&:name)
+    end
+
+    context "with resource creation" do
+
+      let(:method_description) do
+        Apipie.get_method_description(UsersController, :create)
+      end
+
+      it "makes the param required" do
+        required.should include :name
+        required.should include :pass
+      end
+
+      it "doesn't allow nil" do
+        allowed_nil.should_not include :name
+        allowed_nil.should_not include :pass
+      end
+    end
+
+    context "with resource update" do
+
+      let(:method_description) do
+        Apipie.get_method_description(UsersController, :update)
+      end
+
+      it "doesn't make the param required" do
+        required.should_not include :name
+        required.should_not include :pass
+      end
+
+      it "doesn't allow nil" do
+        allowed_nil.should_not include :name
+        allowed_nil.should_not include :pass
+      end
+
+      it "doesn't touch params with explicitly set allow_nil" do
+        allowed_nil.should_not include :membership
+      end
+    end
+  end
 end


### PR DESCRIPTION
In CRUD operations, this pattern occurs quite often: params that need to be
set are:
- for create action: `required => true` and `allow_nil => false`
- for update action: `required => false` and `allow_nil => false`

This makes it hard to share the param definitions across theses actions.
Therefore, you can make the description a bit smarter by setting
`:action_aware => true`.

``` ruby
def_param_group :user do
 param :user, Hash, :action_aware => true do
   param :name, String, :required => true
   param :description, :String
 end
end

api :POST, "/users", "Create an user"
param_group :user def create
 # ...
end

api :PUT, "/users/:id", "Update an user"
param_group :user
def update
 # ...
end
```

In this case, `user[name]` will be not be allowed nil for both actions and
required only for create. Params with `allow_nil` set explicitly don't have
this value changed.

Action awareness is being inherited from ancestors (in terms of nested
params).
