### PR TITLE
Explicitly say as what action the param group should be used

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -331,6 +331,9 @@ This makes it hard to share the param definitions across theses
 actions. Therefore, you can make the description a bit smarter by
 setting ``:action_aware => true``.
 
+You can specify explicitly how the param group should be evaluated
+with ``:as`` option (either :create  or :update)
+
 Example
 ~~~~~~~
 
@@ -349,15 +352,21 @@ Example
      # ...
    end
 
+   api :PUT, "/users/admin", "Create an admin"
+   param_group :user, :as => :create
+   def create_admin
+     # ...
+   end
+
    api :PUT, "/users/:id", "Update an user"
    param_group :user
    def update
      # ...
    end
 
-In this case, ``user[name]`` will be not be allowed nil for both
-actions and required only for create. Params with ``allow_nil`` set
-explicitly don't have this value changed.
+In this case, ``user[name]`` will be not be allowed nil for all
+actions and required only for ``create`` and ``create_admin``. Params
+with ``allow_nil`` set explicitly don't have this value changed.
 
 Action awareness is being inherited from ancestors (in terms of
 nested params).

--- a/lib/apipie/dsl_definition.rb
+++ b/lib/apipie/dsl_definition.rb
@@ -238,9 +238,17 @@ module Apipie
       # Reuses param group for this method. The definition is looked up
       # in scope of this controller. If the group was defined in
       # different controller, the second param can be used to specify it.
-      def param_group(name, scope = nil)
+      # when using action_aware parmas, you can specify :as =>
+      # :create or :update to explicitly say how it should behave
+      def param_group(name, scope_or_options = nil, options = {})
+        if scope_or_options.is_a? Hash
+          options.merge!(scope_or_options)
+          scope = options[:scope]
+        else
+          scope = scope_or_options
+        end
         scope ||= _default_param_group_scope
-        @_current_param_group = {:scope => scope, :name => name}
+        @_current_param_group = {:scope => scope, :name => name, :options => options}
         self.instance_exec(&Apipie.get_param_group(scope, name))
       ensure
         @_current_param_group = nil

--- a/lib/apipie/param_description.rb
+++ b/lib/apipie/param_description.rb
@@ -150,6 +150,17 @@ module Apipie
       end
     end
 
+    def as_action
+      if @options[:param_group] && @options[:param_group][:options] &&
+          @options[:param_group][:options][:as]
+        @options[:param_group][:options][:as].to_s
+      elsif @parent
+        @parent.as_action
+      else
+        @method_description.method
+      end
+    end
+
     # makes modification that are based on the action that the param
     # is defined for. Typical for required and allow_nil variations in
     # crate/update actions.
@@ -162,7 +173,7 @@ module Apipie
             @allow_nil = true
           end
         end
-        if @method_description.method != "create"
+        if as_action != "create"
           @required = false
         end
       end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -29,7 +29,6 @@ describe UsersController do
 
     it "should contain all resource methods" do
       methods = subject._methods
-      methods.count.should == 6
       methods.keys.should include(:show)
       methods.keys.should include(:index)
       methods.keys.should include(:create)

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -218,6 +218,12 @@ class UsersController < ApplicationController
     render :text => "OK #{params.inspect}"
   end
 
+  api :POST, "/users/admin", "Create admin user"
+  param_group :user, :as => :create
+  def admin_create
+    render :text => "OK #{params.inspect}"
+  end
+
   api :GET, "/users", "List users"
   error :code => 401, :desc => "Unauthorized"
   error :code => 404, :desc => "Not Found"

--- a/spec/lib/param_description_spec.rb
+++ b/spec/lib/param_description_spec.rb
@@ -97,5 +97,21 @@ describe Apipie::ParamDescription do
         allowed_nil.should_not include :membership
       end
     end
+
+    context "with explicitly setting action type in param group" do
+      let(:method_description) do
+        Apipie.get_method_description(UsersController, :admin_create)
+      end
+
+      it "makes the param required" do
+        required.should include :name
+        required.should include :pass
+      end
+
+      it "doesn't allow nil" do
+        allowed_nil.should_not include :name
+        allowed_nil.should_not include :pass
+      end
+    end
   end
 end


### PR DESCRIPTION
Influencing action_aware params

``` ruby
api :PUT, "/users/admin", "Create an admin"
param_group :user, :as => :create
def create_admin
 # ...
end
```
