### PR TITLE
When safe_yaml gem is loaded, apipie will fail to load/use examples

### DIFF
--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -207,7 +207,12 @@ module Apipie
       return @recorded_examples if @recorded_examples
       tape_file = File.join(Rails.root,"doc","apipie_examples.yml")
       if File.exists?(tape_file)
-        @recorded_examples = YAML.load_file(tape_file)
+        #if SafeYAML gem is enabled, it will load examples as an array of Hash, instead of hash
+        if defined? SafeYAML
+          @recorded_examples = YAML.load_file(tape_file, :safe=>false)
+        else
+          @recorded_examples = YAML.load_file(tape_file)
+        end
       else
         @recorded_examples = {}
       end

--- a/lib/apipie/extractor/recorder.rb
+++ b/lib/apipie/extractor/recorder.rb
@@ -13,6 +13,7 @@ module Apipie
         @params.merge!(env["action_dispatch.request.request_parameters"] || {})
         if data = parse_data(env["rack.input"].read)
           @request_data = data
+          env["rack.input"].rewind
         end
       end
 

--- a/lib/apipie/extractor/writer.rb
+++ b/lib/apipie/extractor/writer.rb
@@ -99,7 +99,11 @@ module Apipie
 
       def load_old_examples
         if File.exists?(@examples_file)
-          return YAML.load(File.read(@examples_file))
+           if defined? SafeYAML
+              return YAML.load_file(@examples_file, :safe=>false)
+            else
+              return YAML.load_file(@examples_file)
+            end
         end
         return {}
       end


### PR DESCRIPTION
Safe_YAML seems to load the contents of the apipie_examples.yml as an array of hashes, instead of a hash...

Ending in a 

Rack::File headers parameter replaces cache_control after Rack 1.5.
/Users/ajo/.rvm/gems/ruby-1.9.3-p286/bundler/gems/apipie-rails-c4a766ecf6e4/lib/apipie/method_description.rb:149:in `[]': can't convert String into Integer (TypeError)
    from /Users/ajo/.rvm/gems/ruby-1.9.3-p286/bundler/gems/apipie-rails-c4a766ecf6e4/lib/apipie/method_description.rb:149:in`load_recorded_examples'
    from /Users/ajo/.rvm/gems/ruby-1.9.3-p286/bundler/gems/apipie-rails-c4a766ecf6e4/lib/apipie/method_description.rb:41:in `initialize'
    from /Users/ajo/.rvm/gems/ruby-1.9.3-p286/bundler/gems/apipie-rails-c4a766ecf6e4/lib/apipie/application.rb:46:in`new'

When you try to view any of the controllers with an example.

This patch fixes it for the people using SafeYAML, and won't do anything for the people using the traditional yaml :)
