### PR TITLE
[Fixes #104] Record examples considers a defined resource_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ spec/dummy/tmp/
 .idea
 Gemfile.lock
 .rvmrc
+
+.DS_Store

--- a/lib/apipie/extractor/collector.rb
+++ b/lib/apipie/extractor/collector.rb
@@ -19,7 +19,7 @@ module Apipie
       def ignore_call?(record)
         return true unless record[:controller]
         return true if @ignored.include?(record[:controller].name)
-        return true if @ignored.include?("#{record[:controller].name}##{record[:action]}")
+        return true if @ignored.include?("#{Apipie.get_resource_name(record[:controller].name)}##{record[:action]}")
         return true unless @api_controllers_paths.include?(controller_full_path(record[:controller]))
       end
 
@@ -33,7 +33,7 @@ module Apipie
       end
 
       def add_to_records(record)
-        key = "#{record[:controller].controller_name}##{record[:action]}"
+        key = "#{Apipie.get_resource_name(record[:controller])}##{record[:action]}"
         @records[key] << record
       end
 

--- a/spec/controllers/api/v2/nested/resources_controller_spec.rb
+++ b/spec/controllers/api/v2/nested/resources_controller_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Api::V2::Nested::ResourcesController do
+  describe "resource id" do
+    subject { Apipie.get_resource_name(Api::V2::Nested::ResourcesController) }
+
+    it "should have resource_id set" do
+      subject.should eq("resource")
+    end
+  end
+end

--- a/spec/dummy/app/controllers/api/v2/nested/resources_controller.rb
+++ b/spec/dummy/app/controllers/api/v2/nested/resources_controller.rb
@@ -1,0 +1,33 @@
+module Api
+  module V2
+    class Nested::ResourcesController < V2::BaseController
+      resource_description do 
+        name 'Resources'
+        resource_id "resource"
+      end
+      api :GET, "/nested/resources/", "List all nested resources."
+      def index
+      end
+
+      api :GET, "/nested/resources/:id/", "Show a nested resource."
+      def show
+      end
+
+      api :POST, "/nested/resources/", "Create a nested resource."
+      param_group :arch, Api::V1::ArchitecturesController
+      def create
+      end
+
+      api :PUT, "/nested/resources/:id/", "Update a nested resource."
+      param :architecture, Hash, :required => true do
+        param :name, String
+      end
+      def update
+      end
+
+      api :DELETE, "/resources/:id/", "Delete a nested resource."
+      def destroy
+      end
+    end
+  end
+end


### PR DESCRIPTION
Considers custom resource_ids during example recording.
