### PR TITLE
[Fixes #104] Allow nested resources with the same name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -427,6 +427,10 @@ ignored
   to be ignored when generationg the documentation
   e.g. ``%w[Api::CommentsController Api::PostsController#post]``
 
+namespaced_resources
+  Use controller paths instead of controller names as resource id.
+  This prevents same named controllers overwriting each other.
+
 
 Example:
 

--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -276,6 +276,10 @@ module Apipie
         klass
       elsif @controller_to_resource_id.has_key?(klass)
         @controller_to_resource_id[klass]
+      elsif Apipie.configuration.namespaced_resources? && klass.respond_to?(:controller_path)
+        return nil if klass == ActionController::Base
+        path = klass.controller_path
+        path.gsub(version_prefix(klass), "").gsub("/", "-")
       elsif klass.respond_to?(:controller_name)
         return nil if klass == ActionController::Base
         klass.controller_name
@@ -285,6 +289,12 @@ module Apipie
     end
 
     private
+
+    def version_prefix(klass)
+      version = controller_versions(klass).first
+      path = Apipie.configuration.api_base_url[version]
+      path[1..-1] + "/"
+    end
 
     def get_resource_version(resource_description)
       if resource_description.respond_to? :_version

--- a/lib/apipie/configuration.rb
+++ b/lib/apipie/configuration.rb
@@ -3,10 +3,11 @@ module Apipie
 
     attr_accessor :app_name, :app_info, :copyright, :markup, :disqus_shortname,
       :validate, :api_base_url, :doc_base_url, :required_by_default, :layout,
-      :default_version, :debug, :version_in_url
+      :default_version, :debug, :version_in_url, :namespaced_resources
 
     alias_method :validate?, :validate
     alias_method :required_by_default?, :required_by_default
+    alias_method :namespaced_resources?, :namespaced_resources
 
     # matcher to be used in Dir.glob to find controllers to be reloaded e.g.
     #
@@ -107,6 +108,7 @@ module Apipie
       @default_version = "1.0"
       @debug = false
       @version_in_url = true
+      @namespaced_resources = false
     end
   end
 end

--- a/spec/dummy/app/controllers/api/v2/nested/architectures_controller.rb
+++ b/spec/dummy/app/controllers/api/v2/nested/architectures_controller.rb
@@ -1,0 +1,30 @@
+module Api
+  module V2
+    class Nested::ArchitecturesController < V2::BaseController
+      resource_description { name 'Architectures' }
+      api :GET, "/nested/architectures/", "List all nested architectures."
+      def index
+      end
+
+      api :GET, "/nested/architectures/:id/", "Show a nested architecture."
+      def show
+      end
+
+      api :POST, "/nested/architectures/", "Create a nested architecture."
+      param_group :arch, Api::V1::ArchitecturesController
+      def create
+      end
+
+      api :PUT, "/nested/architectures/:id/", "Update a nested architecture."
+      param :architecture, Hash, :required => true do
+        param :name, String
+      end
+      def update
+      end
+
+      api :DELETE, "/architecturess/:id/", "Delete a nested architecture."
+      def destroy
+      end
+    end
+  end
+end

--- a/spec/lib/application_spec.rb
+++ b/spec/lib/application_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe Apipie::Application do
+
+  describe "get_resource_name" do
+    subject {Apipie.get_resource_name(Api::V2::Nested::ArchitecturesController)}
+    context "with namespaced_resources enabled" do
+      before { Apipie.configuration.namespaced_resources = true }
+
+      it "should not overwrite the parent resource" do
+        subject.should_not eq(Apipie.get_resource_name(Api::V2::ArchitecturesController))
+      end
+    end
+
+    context "with namespaced_resources enabled" do
+      before { Apipie.configuration.namespaced_resources = false }
+
+      it "should overwrite the the parent" do
+        subject.should eq(Apipie.get_resource_name(Api::V2::ArchitecturesController))
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR allows nested resources to have the same name as the parent and doesn't overwrite their documentation by default. In the current version you have to set a custom resource_id, if the controller names were equal.
