### PR TITLE
Problem installing with Ruby 2.0 + RDoc 4.0

### DIFF
--- a/lib/apipie/markup.rb
+++ b/lib/apipie/markup.rb
@@ -7,7 +7,11 @@ module Apipie
       def initialize
         require 'rdoc'
         require 'rdoc/markup/to_html'
-        @rdoc ||= ::RDoc::Markup::ToHtml.new
+        if Gem::Version.new(::RDoc::VERSION) < Gem::Version.new('4.0.0')
+          @rdoc ||= ::RDoc::Markup::ToHtml.new()
+        else
+          @rdoc ||= ::RDoc::Markup::ToHtml.new(::RDoc::Options.new)
+        end
       end
 
       def to_html(text)


### PR DESCRIPTION
I was trying to update the Fedora 19 package but the installation failed:

```
$ gem install --local --document=ri,rdoc --force /builddir/build/SOURCES/apipie-rails-0.0.20.gem
Successfully installed apipie-rails-0.0.20
Parsing documentation for apipie-rails-0.0.20
Installing ri documentation for apipie-rails-0.0.20
Installing darkfish documentation for apipie-rails-0.0.20
ERROR:  While executing gem ... (RDoc::Error)
    error generating /usr/local/share/gems/doc/apipie-rails-0.0.20/rdoc/lib/generators/apipie/install/install_generator_rb.html: Error while evaluating /usr/share/gems/gems/rdoc-4.0.0/lib/rdoc/generator/template/darkfish/page.rhtml: undefined method `chomp' for nil:NilClass (RDoc::Error)
```

I was previously trying older version and it Failed with different error:

```
$ rspec spec
/usr/share/gems/gems/rdoc-4.0.0/lib/rdoc/markup/to_html.rb:44:in `initialize': wrong number of arguments (0 for 1..2) (ArgumentError)
    from /builddir/build/BUILD/rubygem-apipie-rails-0.0.13/usr/share/gems/gems/apipie-rails-0.0.13/lib/apipie/markup.rb:10:in `new'
    from /builddir/build/BUILD/rubygem-apipie-rails-0.0.13/usr/share/gems/gems/apipie-rails-0.0.13/lib/apipie/markup.rb:10:in `initialize'
    from /builddir/build/BUILD/rubygem-apipie-rails-0.0.13/usr/share/gems/gems/apipie-rails-0.0.13/lib/apipie/apipie_module.rb:100:in `new'
    from /builddir/build/BUILD/rubygem-apipie-rails-0.0.13/usr/share/gems/gems/apipie-rails-0.0.13/lib/apipie/apipie_module.rb:100:in `initialize'
    from /builddir/build/BUILD/rubygem-apipie-rails-0.0.13/usr/share/gems/gems/apipie-rails-0.0.13/lib/apipie/apipie_module.rb:25:in `new'
    from /builddir/build/BUILD/rubygem-apipie-rails-0.0.13/usr/share/gems/gems/apipie-rails-0.0.13/lib/apipie/apipie_module.rb:25:in `configuration'
    from /builddir/build/BUILD/rubygem-apipie-rails-0.0.13/usr/share/gems/gems/apipie-rails-0.0.13/lib/apipie/apipie_module.rb:21:in `configure'
    from /builddir/build/BUILD/rubygem-apipie-rails-0.0.13/usr/share/gems/gems/apipie-rails-0.0.13/spec/dummy/config/initializers/apipie.rb:1:in `<top (required)>'
    from /usr/share/gems/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:245:in `load'
    from /usr/share/gems/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:245:in `block in load'
    from /usr/share/gems/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:236:in `load_dependency'
    from /usr/share/gems/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:245:in `load'
    from /usr/share/gems/gems/railties-3.2.13/lib/rails/engine.rb:588:in `block (2 levels) in <class:Engine>'
    from /usr/share/gems/gems/railties-3.2.13/lib/rails/engine.rb:587:in `each'
    from /usr/share/gems/gems/railties-3.2.13/lib/rails/engine.rb:587:in `block in <class:Engine>'
    from /usr/share/gems/gems/railties-3.2.13/lib/rails/initializable.rb:30:in `instance_exec'
    from /usr/share/gems/gems/railties-3.2.13/lib/rails/initializable.rb:30:in `run'
    from /usr/share/gems/gems/railties-3.2.13/lib/rails/initializable.rb:55:in `block in run_initializers'
    from /usr/share/gems/gems/railties-3.2.13/lib/rails/initializable.rb:54:in `each'
    from /usr/share/gems/gems/railties-3.2.13/lib/rails/initializable.rb:54:in `run_initializers'
    from /usr/share/gems/gems/railties-3.2.13/lib/rails/application.rb:136:in `initialize!'
    from /usr/share/gems/gems/railties-3.2.13/lib/rails/railtie/configurable.rb:30:in `method_missing'
    from /builddir/build/BUILD/rubygem-apipie-rails-0.0.13/usr/share/gems/gems/apipie-rails-0.0.13/spec/dummy/config/environment.rb:8:in `<top (required)>'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:45:in `require'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:45:in `require'
    from /builddir/build/BUILD/rubygem-apipie-rails-0.0.13/usr/share/gems/gems/apipie-rails-0.0.13/spec/spec_helper.rb:4:in `<top (required)>'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:45:in `require'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:45:in `require'
    from /builddir/build/BUILD/rubygem-apipie-rails-0.0.13/usr/share/gems/gems/apipie-rails-0.0.13/spec/controllers/apipies_controller_spec.rb:1:in `<top (required)>'
    from /usr/share/gems/gems/rspec-core-2.13.1/lib/rspec/core/configuration.rb:819:in `load'
    from /usr/share/gems/gems/rspec-core-2.13.1/lib/rspec/core/configuration.rb:819:in `block in load_spec_files'
    from /usr/share/gems/gems/rspec-core-2.13.1/lib/rspec/core/configuration.rb:819:in `each'
    from /usr/share/gems/gems/rspec-core-2.13.1/lib/rspec/core/configuration.rb:819:in `load_spec_files'
    from /usr/share/gems/gems/rspec-core-2.13.1/lib/rspec/core/command_line.rb:22:in `run'
    from /usr/share/gems/gems/rspec-core-2.13.1/lib/rspec/core/runner.rb:80:in `run'
    from /usr/share/gems/gems/rspec-core-2.13.1/lib/rspec/core/runner.rb:17:in `block in autorun'
```
