### PR TITLE
Rename validate_type to validate_presence

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -478,6 +478,13 @@ default_version
 validate
   Parameters validation is turned off when set to false.
 
+validate_value
+  Check the value of params against specified validators (true by
+  default)
+
+validate_presence
+  Check the params presence against the documentation.
+
 app_info
   Application long description.
 

--- a/lib/apipie/configuration.rb
+++ b/lib/apipie/configuration.rb
@@ -4,7 +4,7 @@ module Apipie
     attr_accessor :app_name, :app_info, :copyright, :markup, :disqus_shortname,
       :api_base_url, :doc_base_url, :required_by_default, :layout,
       :default_version, :debug, :version_in_url, :namespaced_resources,
-      :validate, :validate_type, :validate_presence
+      :validate, :validate_value, :validate_presence
 
 
     alias_method :validate?, :validate
@@ -26,10 +26,10 @@ module Apipie
       return @reload_controllers && @api_controllers_matcher
     end
 
-    def validate_type
-      return (validate? && @validate_type)
+    def validate_value
+      return (validate? && @validate_value)
     end
-    alias_method :validate_type?, :validate_type
+    alias_method :validate_value?, :validate_value
 
     def validate_presence
       return (validate? && @validate_presence)
@@ -112,7 +112,7 @@ module Apipie
       @app_info = HashWithIndifferentAccess.new
       @copyright = nil
       @validate = true
-      @validate_type = true
+      @validate_value = true
       @validate_presence = true
       @required_by_default = false
       @api_base_url = HashWithIndifferentAccess.new

--- a/lib/apipie/dsl_definition.rb
+++ b/lib/apipie/dsl_definition.rb
@@ -182,7 +182,7 @@ module Apipie
               end
             end
 
-            if Apipie.configuration.validate_type?
+            if Apipie.configuration.validate_value?
               description.params.each do |_, param|
                 # params validations
                 param.validate(params[:"#{param.name}"]) if params.has_key?(param.name)

--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -208,7 +208,7 @@ module Apipie
             if Apipie.configuration.validate_presence?
               raise ParamMissing.new(k) if p.required && !value.has_key?(k)
             end
-            if Apipie.configuration.validate_type?
+            if Apipie.configuration.validate_value?
               p.validate(value[k]) if value.has_key?(k)
             end
           end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -59,7 +59,7 @@ describe UsersController do
     context "validations are disabled" do
       before do
         Apipie.configuration.validate = false
-        Apipie.configuration.validate_type = true
+        Apipie.configuration.validate_value = true
         Apipie.configuration.validate_presence = true
       end
 
@@ -77,7 +77,7 @@ describe UsersController do
     context "only presence validations are enabled" do
       before do
         Apipie.configuration.validate = true
-        Apipie.configuration.validate_type = false
+        Apipie.configuration.validate_value = false
         Apipie.configuration.validate_presence = true
       end
 
@@ -101,7 +101,7 @@ describe UsersController do
     context "validations are enabled" do
       before do
         Apipie.configuration.validate = true
-        Apipie.configuration.validate_type = true
+        Apipie.configuration.validate_value = true
         Apipie.configuration.validate_presence = true
       end
 


### PR DESCRIPTION
Validate_type option was not part of any release yet, no need for deprecation.
