### PR TITLE
[Fixes #109] Nested resources with undefined base urls.

### DIFF
--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -292,8 +292,13 @@ module Apipie
 
     def version_prefix(klass)
       version = controller_versions(klass).first
-      path = Apipie.configuration.api_base_url[version]
-      path[1..-1] + "/"
+      base_url = get_base_url(version)
+      return "/" if base_url.nil?
+      base_url[1..-1] + "/"
+    end
+
+    def get_base_url(version)
+      Apipie.configuration.api_base_url[version]
     end
 
     def get_resource_version(resource_description)

--- a/spec/lib/application_spec.rb
+++ b/spec/lib/application_spec.rb
@@ -4,19 +4,34 @@ describe Apipie::Application do
 
   describe "get_resource_name" do
     subject {Apipie.get_resource_name(Api::V2::Nested::ArchitecturesController)}
+
     context "with namespaced_resources enabled" do
       before { Apipie.configuration.namespaced_resources = true }
-
-      it "should not overwrite the parent resource" do
-        subject.should_not eq(Apipie.get_resource_name(Api::V2::ArchitecturesController))
+      context "with a defined base url" do
+        
+        it "should not overwrite the parent resource" do
+          should_not eq(Apipie.get_resource_name(Api::V2::ArchitecturesController))
+        end
+        
       end
+
+      context "with an undefined base url" do
+        before {Apipie.app.stub(:get_base_url) { nil }}
+
+        it "should not raise an error" do
+          expect { Apipie.get_resource_name(Api::V2::ArchitecturesController) }.
+            not_to raise_error
+        end
+      end
+
+      after { Apipie.configuration.namespaced_resources = false }
     end
 
     context "with namespaced_resources enabled" do
       before { Apipie.configuration.namespaced_resources = false }
 
       it "should overwrite the the parent" do
-        subject.should eq(Apipie.get_resource_name(Api::V2::ArchitecturesController))
+        should eq(Apipie.get_resource_name(Api::V2::ArchitecturesController))
       end
     end
   end


### PR DESCRIPTION
Fixes `undefined method '[]' for nil:NilClass` with nested resources enabled and an undefined base url for the controller.
