### PR TITLE
Add optional title attribute to the code examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1117,11 +1117,15 @@ The data is written into ``doc/apipie_examples.yml``. By default,
 only the first example is shown for each action. You can customize
 this by setting ``show_in_doc`` attribute at each example.
 
+You can add a title to the examples (useful when showing more than
+one example per method) by adding a 'title' attribute.
+
 .. code::
 
    --- !omap
      - announcements#index:
        - !omap
+         - title: This is a custom title for this example
          - verb: :GET
          - path: /api/blabla/1
          - versions:

--- a/lib/apipie/configuration.rb
+++ b/lib/apipie/configuration.rb
@@ -6,7 +6,8 @@ module Apipie
       :default_version, :debug, :version_in_url, :namespaced_resources,
       :validate, :validate_value, :validate_presence, :validate_key, :authenticate, :doc_path,
       :show_all_examples, :process_params, :update_checksum, :checksum_path,
-      :link_extension, :record, :languages, :translate, :locale, :default_locale
+      :link_extension, :record, :languages, :translate, :locale, :default_locale,
+      :persist_show_in_doc
 
     alias_method :validate?, :validate
     alias_method :required_by_default?, :required_by_default
@@ -91,6 +92,10 @@ module Apipie
       @ignored.map(&:to_s)
     end
 
+    # Persist the show_in_doc value in the examples if true. Use this if you
+    # cannot set the flag in the tests themselves (no rspec for example).
+    attr_writer :persist_show_in_doc
+
     # comment to put before docs that was generated automatically. It's used to
     # determine if the description should be overwritten next recording.
     # If you want to keep the documentation (prevent from overriding), remove
@@ -152,6 +157,7 @@ module Apipie
       @default_locale = 'en'
       @locale = lambda { |locale| @default_locale }
       @translate = lambda { |str, locale| str }
+      @persist_show_in_doc = false
     end
   end
 end

--- a/lib/apipie/method_description.rb
+++ b/lib/apipie/method_description.rb
@@ -174,7 +174,9 @@ module Apipie
     end
 
     def format_example(ex)
-      example = "#{ex[:verb]} #{ex[:path]}"
+      example = ""
+      example << "// #{ex[:title]}\n" if ex[:title].present?
+      example << "#{ex[:verb]} #{ex[:path]}"
       example << "?#{ex[:query]}" unless ex[:query].blank?
       example << "\n" << format_example_data(ex[:request_data]).to_s if ex[:request_data]
       example << "\n" << ex[:code].to_s


### PR DESCRIPTION
1. Add optional title attribute to the code examples
2. Let the show_in_doc and title keys survive example regeneration (with added config flag)

Let me know if there are any changes you need before you can merge this.
