### PR TITLE
Fix for concern substitution spoiling parameter names

### DIFF
--- a/lib/apipie/param_description.rb
+++ b/lib/apipie/param_description.rb
@@ -180,16 +180,16 @@ module Apipie
     end
 
     def concern_subst(string)
-      return if string.nil?
+      return string if string.nil? or !method_description.from_concern?
+
       original = string
-      if method_description.from_concern?
-        string = ":#{original}" if original.is_a? Symbol
-        ret = method_description.resource.controller._apipie_perform_concern_subst(string)
-        ret = ret.to_sym if original.is_a? Symbol
-        ret
-      else
-        string
-      end
+      string = ":#{original}" if original.is_a? Symbol
+
+      replaced = method_description.resource.controller._apipie_perform_concern_subst(string)
+
+      return original if replaced == string
+      return replaced.to_sym if original.is_a? Symbol
+      return replaced
     end
 
   end

--- a/spec/dummy/app/controllers/concerns_controller.rb
+++ b/spec/dummy/app/controllers/concerns_controller.rb
@@ -2,7 +2,7 @@ class ConcernsController < ApplicationController
 
   resource_description { resource_id 'concern_resources' }
 
-  apipie_concern_subst(:concern => 'user', :custom_subst => 'custom')
+  apipie_concern_subst(:concern => 'user', :custom_subst => 'custom', 'string_subst' => 'string')
   include ::Concerns::SampleController
 
 end

--- a/spec/lib/param_description_spec.rb
+++ b/spec/lib/param_description_spec.rb
@@ -13,6 +13,45 @@ describe Apipie::ParamDescription do
   end
 
 
+  describe "concern substitution" do
+
+    let(:concern_dsl_data) { dsl_data.merge(:from_concern => true) }
+
+    let(:concern_resource_desc) do
+      Apipie::ResourceDescription.new(ConcernsController, "concerns")
+    end
+
+    let(:concern_method_desc) do
+      Apipie::MethodDescription.new(:show, concern_resource_desc, concern_dsl_data)
+    end
+
+    it "should replace string parameter name with colon prefix" do
+      param = Apipie::ParamDescription.new(concern_method_desc, ":string_subst", String)
+      param.name.should == "string"
+    end
+
+    it "should replace symbol parameter name" do
+      param = Apipie::ParamDescription.new(concern_method_desc, :concern, String)
+      param.name.should == :user
+    end
+
+    it "should keep original value for strings without colon prefixes" do
+      param = Apipie::ParamDescription.new(concern_method_desc, "string_subst", String)
+      param.name.should == "string_subst"
+    end
+
+    it "should keep the original value when a string can't be replaced" do
+      param = Apipie::ParamDescription.new(concern_method_desc, ":param", String)
+      param.name.should == ":param"
+    end
+
+    it "should keep the original value when a symbol can't be replaced" do
+      param = Apipie::ParamDescription.new(concern_method_desc, :param, String)
+      param.name.should == :param
+    end
+  end
+
+
   describe "required_by_default config option" do
     context "parameters required by default" do
 


### PR DESCRIPTION
Concern substitution was spoiling parameter names that could not be replaced.
Eg. parameter :name ended up as :":name" at the function's output.
