### PR TITLE
Use StandardError instead of Exception

### DIFF
--- a/lib/apipie/extractor/recorder.rb
+++ b/lib/apipie/extractor/recorder.rb
@@ -46,7 +46,7 @@ module Apipie
       def parse_data(data)
         return nil if data.to_s =~ /^\s*$/
         JSON.parse(data)
-      rescue Exception => e
+      rescue StandardError => e
         data
       end
 

--- a/lib/apipie/extractor/writer.rb
+++ b/lib/apipie/extractor/writer.rb
@@ -140,9 +140,9 @@ module Apipie
 
     class ActionDescriptionUpdater
 
-      class ControllerNotFound < Exception; end
+      class ControllerNotFound < StandardError; end
 
-      class ActionNotFound < Exception; end
+      class ActionNotFound < StandardError; end
 
       def initialize(controller, action)
         @controller = controller

--- a/lib/apipie/param_description.rb
+++ b/lib/apipie/param_description.rb
@@ -61,7 +61,7 @@ module Apipie
       return true if @allow_nil && value.nil?
       unless @validator.valid?(value)
         error = @validator.error
-        error = ParamError.new(error) unless error.is_a? Exception
+        error = ParamError.new(error) unless error.is_a? StandardError
         raise error
       end
     end


### PR DESCRIPTION
It's generally not a good idea to rescue from `Exception`.

See [this blog post](http://daniel.fone.net.nz/blog/2013/05/28/why-you-should-never-rescue-exception-in-ruby/) for more details.
