### PR TITLE
Fixed deprecation warning that occurs in Rails 4.0

### DIFF
--- a/lib/apipie/static_dispatcher.rb
+++ b/lib/apipie/static_dispatcher.rb
@@ -27,9 +27,18 @@ module Apipie
 
     def ext
       @ext ||= begin
-        ext = ::ActionController::Base.page_cache_extension
+        ext = cache_extension
         "{,#{ext},/index#{ext}}"
       end
+    end
+
+    def cache_extension
+      if ::ActionController::Base.respond_to?(:default_static_extension)
+        ::ActionController::Base.default_static_extension
+      else
+        ::ActionController::Base.page_cache_extension
+      end
+
     end
   end
 


### PR DESCRIPTION
We noticed a Rails 4.0 deprecation warning when running our specs and traced it back to the static_dispatcher in apipie-rails. Have a look if you conceptually agree with my fix and merge at your leisure. It should be compatible with previous versions of Rails and all the tests pass.
