### PR TITLE
do not call `Apipie::Extractor.call_finished` when exception raised

### DIFF
--- a/lib/apipie/extractor.rb
+++ b/lib/apipie/extractor.rb
@@ -41,7 +41,9 @@ module Apipie
         if record = call_recorder.record
           @collector.handle_record(record)
         end
-      ensure
+      end
+
+      def clean_call_recorder
         Thread.current[:apipie_call_recorder] = nil
       end
 

--- a/lib/apipie/extractor/recorder.rb
+++ b/lib/apipie/extractor/recorder.rb
@@ -98,9 +98,10 @@ module Apipie
           Apipie::Extractor.call_recorder.analyse_env(env)
           response = block.call
           Apipie::Extractor.call_recorder.analyse_response(response)
+          Apipie::Extractor.call_finished
           response
         ensure
-          Apipie::Extractor.call_finished
+          Apipie::Extractor.clean_call_recorder
         end
       end
 
@@ -112,9 +113,10 @@ module Apipie
         def process_with_api_recording(*args) # action, parameters = nil, session = nil, flash = nil, http_method = 'GET')
           ret = process_without_api_recording(*args)
           Apipie::Extractor.call_recorder.analyze_functional_test(self)
+          Apipie::Extractor.call_finished
           ret
         ensure
-          Apipie::Extractor.call_finished
+          Apipie::Extractor.clean_call_recorder
         end
       end
 

--- a/spec/lib/param_description_spec.rb
+++ b/spec/lib/param_description_spec.rb
@@ -24,7 +24,7 @@ describe Apipie::ParamDescription do
     end
 
     it "should pick type validator" do
-      Apipie::Validator::BaseValidator.should receive(:find).and_return(:validator_instance)
+      Apipie::Validator::BaseValidator.should_receive(:find).and_return(:validator_instance)
       param = Apipie::ParamDescription.new(method_desc, :param, String)
       param.validator.should == :validator_instance
     end


### PR DESCRIPTION
When I record example from my controller spec,  and the spec failed for some reason, I will see a stack trace like this:

``` ruby
NoMethodError:
       undefined method `each' for nil:NilClass
     # ./spec/controllers/examples_controller_spec.rb:33:in `block (4 levels) in <top (required)>'
     # ./spec/controllers/examples_controller_spec.rb:39:in `block (4 levels) in <top (required)>'
```

it take me nearly one hour to figure what's actually wrong.

actually, the error was raised from : `lib/apipie/extractor/collector.rb:56`, because `apipie` can not record some data when spec failed.

I think  it dosen't make sense to call the `Apipie::Extractor.call_finished` when spec already failed, so I create this pull request.

thoughts?
