### PR TITLE
Patch XSS Vulnerability for now

### DIFF
--- a/app/views/apipie/apipies/index.html.erb
+++ b/app/views/apipie/apipies/index.html.erb
@@ -2,7 +2,7 @@
   <li class='active'><a href='<%= @doc[:doc_url] %>.html'><%= @doc[:name] %> <%= @doc[:resources].values.first[:version] %></a></li>
   <% if @versions && @versions.size > 1 %>
   <li class='pull-right'>
-    <%= @versions.collect { |v| link_to v, Apipie.full_url(v) }.join(' / ').html_safe %>
+    <%#= @versions.collect { |v| link_to v, Apipie.full_url(v) }.join(' / ').html_safe %>
   </li>
   <% end %>
 </ul>


### PR DESCRIPTION
This is a vulnerability in apipie-rails right now.  We saw some bots come through and accidentally inject arbitrary text/javascript on the page.  We think it was done by setting @versions in the url string, with something like this: http://localhost:3000/api/doc?version=%3Cb%3Efoo%3C/b%3E (but was difficult to determine exactly how).

The `html_safe` on the end is dangerous in this situation.  You could do something like this instead:

  <% @versions.each do |v| %>
     <%= link_to v, Apipie.full_url(v) %>
  <% end %>

Which would prevent injected js from running, but bots could still inject arbitrary text on the page to deface it.  If the pages are being generated and then cached (using the use_cache apipie setting) all future users (even to the regular url) will see the defaced/hacked page.

This is just a temporary fix.  The real solution would be to avoid letting the @versions parameter get set to invalid values by something in the url.  Hope it is a good start to a fix!
