### PR TITLE
exception if an array is sent as parameter

### DIFF
--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -211,7 +211,7 @@ module Apipie
               raise ParamMissing.new(k) if p.required && !value.has_key?(k)
             end
             if Apipie.configuration.validate_value?
-              p.validate(value[k]) if value.has_key?(k)
+              p.validate(value[k]) if value.respond_to?(:has_key?) and value.has_key?(k)
             end
           end
         end


### PR DESCRIPTION
When receiving a json array to a hash validator there's an exception because array doesn't have "has_key?"

this is a temporary solution (although somewhat correct) until I figure out how to create an arrayvalidator inline
