### PR TITLE
Fix DOS vulnerability for running in production without use_cache

### DIFF
--- a/app/controllers/apipie/apipies_controller.rb
+++ b/app/controllers/apipie/apipies_controller.rb
@@ -28,10 +28,19 @@ module Apipie
         @doc = Apipie.to_json(params[:version], params[:resource], params[:method])
 
         format.json do
-          render :json => @doc
+          if @doc
+            render :json => @doc
+          else
+            head :not_found
+          end
         end
 
         format.html do
+          unless @doc
+            render 'apipie_404', :status => 404
+            return
+          end
+
           @versions = Apipie.available_versions
           @doc = @doc[:docs]
           if @doc[:resources].blank?

--- a/app/views/apipie/apipies/apipie_404.html.erb
+++ b/app/views/apipie/apipies/apipie_404.html.erb
@@ -9,4 +9,6 @@
   </small>
 </h1>
 
-Try going to <a href='<%= @doc[:doc_url] %>.html'><%= @doc[:name] %> API documentation homepage</a>
+<% if @doc %>
+  Try going to <a href='<%= @doc[:doc_url] %>.html'><%= @doc[:name] %> API documentation homepage</a>
+<% end %>

--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -225,6 +225,8 @@ module Apipie
 
     def to_json(version, resource_name, method_name)
 
+      return unless resource_descriptions.has_key?(version)
+
       _resources = if resource_name.blank?
         # take just resources which have some methods because
         # we dont want to show eg ApplicationController as resource


### PR DESCRIPTION
With special crafted url params there was possible to make server unresponsive 
due to memory consumption.

This issue occurred only for setups running without `use_cache = true` in 
production environment.
