### PR TITLE
Camelize correctly controllers whose name has multiple :: in it

### DIFF
--- a/lib/apipie/extractor.rb
+++ b/lib/apipie/extractor.rb
@@ -86,7 +86,8 @@ module Apipie
           controller_path, action = route[:controller], route[:action]
           next unless controller_path && action
 
-          controller = "#{controller_path}_controller".camelize
+          controller_path = controller_path.split('::').map(&:camelize).join('::')
+          controller = "#{controller_path}Controller"
 
           path = if /^#{Regexp.escape(api_prefix)}(.*)$/ =~ route[:path]
                    $1.sub!(/\(\.:format\)$/,"")


### PR DESCRIPTION
When you have a controller names V1::Level1::Level2Contorller whose path is v1/level1/level2_controller it is camelized wrongly as V1::Level1::level2Contorller
