### PR TITLE
Hash parameters validate themselves before their children now to avoid NoMethodError being raised

### DIFF
--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -227,9 +227,7 @@ module Apipie
       end
 
       def validate(value)
-        if !value.is_a? Hash
-          return false
-        end
+        return false if !value.is_a? Hash
         if @hash_params
           @hash_params.each do |k, p|
             if Apipie.configuration.validate_presence?

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -199,6 +199,10 @@ describe UsersController do
           post :create, :user => { :name => "root" }
         }.should raise_error(Apipie::ParamMissing, /pass/)
 
+        lambda {
+          post :create, :user => "a string is not a hash"
+        }.should raise_error(Apipie::ParamInvalid, /user/)
+
         post :create, :user => { :name => "root", :pass => "pwd" }
         assert_response :success
       end


### PR DESCRIPTION
fixes #182
