### PR TITLE
Fix exception when passing a nil value for a hash param required in a hash

### DIFF
--- a/lib/apipie/param_description.rb
+++ b/lib/apipie/param_description.rb
@@ -59,7 +59,7 @@ module Apipie
 
     def validate(value)
       return true if @allow_nil && value.nil?
-      unless @validator.valid?(value)
+      if (!@allow_nil && value.nil?) || !@validator.valid?(value)
         error = @validator.error
         error = ParamError.new(error) unless error.is_a? StandardError
         raise error

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -110,6 +110,13 @@ describe UsersController do
         assert_response :success
       end
 
+      it "should work with nil value for a required hash param" do
+        expect {
+          get :show, :id => '5', :session => "secret_hash", :hash_param => {:dummy_hash => nil}
+        }.to raise_error(Apipie::ParamInvalid, /dummy_hash/)
+        assert_response :success
+      end
+
       it "should fail if required parameter is missing" do
         lambda { get :show, :id => 5 }.should raise_error(Apipie::ParamMissing, /\bsession\b/)
       end
@@ -301,8 +308,8 @@ describe UsersController do
 
     it "should contain all params description" do
       a = Apipie.get_method_description(UsersController, :show)
-      a.params.count.should == 9
-      a.instance_variable_get('@params_ordered').count.should == 7
+      a.params.count.should == 10
+      a.instance_variable_get('@params_ordered').count.should == 8
     end
 
     it "should contain all api method description" do

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -177,6 +177,11 @@ class UsersController < ApplicationController
     val == "param value" ? true : "The only good value is 'param value'."
   }, :desc => "proc validator"
   param :briefer_dsl, String, "You dont need :desc => from now"
+  param :hash_param, Hash, :desc => "Hash param" do
+    param :dummy_hash, Hash do
+      param :dummy_2, String, :required => true
+    end
+  end
   def show
     unless params[:session] == "secret_hash"
       render :text => "Not authorized", :status => 401


### PR DESCRIPTION
Previously the error raised was:

```
undefined method `has_key?' for nil:NilClass
```

https://github.com/Pajk/apipie-rails/blob/master/lib/apipie/validator.rb#L237
