### PR TITLE
Add possiblity to generate the json version of the documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -797,7 +797,8 @@ This will copy the Apipie views to ``app/views/apipie/apipies`` and
 To generate a static version of documentation (perhaps to put it on
 project site or something) run ``rake apipie:static`` task. It will
 create set of html files (multi-pages, single-page, plain) in your doc
-directory. By default the documentation for default API version is
+directory. If you prefer a json version run ``rake apipie:static_json``.
+By default the documentation for default API version is
 used, you can specify the version with ``rake apipie:static[2.0]``
 
 When you want to avoid any unnecessary computation in production mode,

--- a/lib/tasks/apipie.rake
+++ b/lib/tasks/apipie.rake
@@ -35,6 +35,16 @@ namespace :apipie do
     end
   end
 
+  desc "Generate static documentation json"
+  task :static_json, [:version] => :environment do |t, args|
+    with_loaded_documentation do
+      args.with_defaults(:version => Apipie.configuration.default_version)
+      out = ENV["OUT"] || File.join(::Rails.root, 'doc', 'apidoc')
+      doc = Apipie.to_json(args[:version])
+      generate_json_page(out, doc)
+    end
+  end
+
   desc "Generate cache to avoid production dependencies on markup languages"
   task :cache => :environment do
     with_loaded_documentation do
@@ -77,6 +87,13 @@ namespace :apipie do
         :template => "#{template}",
         :layout => (layout && "../../layouts/apipie/#{layout}"))
     end
+  end
+
+  def generate_json_page(file_base, doc)
+    FileUtils.mkdir_p(file_base) unless File.exists?(file_base)
+
+    filename = 'schema_apipie.json'
+    File.open("#{file_base}/#{filename}", 'w') { |file| file.write(JSON.pretty_generate(doc)) }
   end
 
   def generate_one_page(file_base, doc)


### PR DESCRIPTION
Some people (like me) could prefer a json version of the documentation to easily track changes.

We just have to run `rake apipie:static_json` to generate it to `doc/apidoc/schema_apipie.json`.

I use JSON.pretty_generate to generate the json for a better format.
