### PR TITLE
Changes Application#recorded_examples to better respect SafeYAML

### DIFF
--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -208,8 +208,8 @@ module Apipie
       tape_file = File.join(Rails.root,"doc","apipie_examples.yml")
       if File.exists?(tape_file)
         #if SafeYAML gem is enabled, it will load examples as an array of Hash, instead of hash
-        if defined? SafeYAML
-          @recorded_examples = YAML.load_file(tape_file, :safe=>false)
+        if YAML.respond_to?(:safe_load_file) && defined?(SafeYAML)
+          @recorded_examples = SafeYAML.load_file(tape_file, :safe=>false)
         else
           @recorded_examples = YAML.load_file(tape_file)
         end


### PR DESCRIPTION
It's possible for SafeYAML to be defined, but without having done the method patching in default YAML. This change tightens the check for SafeYAML to ensure that the correct api is used.
