### PR TITLE
Copyright appear multiple times in docs generated via rake task (`apipie:static`)

### DIFF
--- a/app/views/apipie/apipies/index.html.erb
+++ b/app/views/apipie/apipies/index.html.erb
@@ -39,5 +39,5 @@
 <% end %>
 
 <% unless content_for(:apipie_footer) == @doc[:copyright] %>
-  <%= provide :apipie_footer, raw(@doc[:copyright]) %>
+  <%= content_for :apipie_footer, raw(@doc[:copyright]) %>
 <% end %>

--- a/app/views/apipie/apipies/method.html.erb
+++ b/app/views/apipie/apipies/method.html.erb
@@ -31,5 +31,5 @@
 </div>
 
 <% unless content_for(:apipie_footer) == @doc[:copyright] %>
-  <%= provide :apipie_footer, raw(@doc[:copyright]) %>
+  <%= content_for :apipie_footer, raw(@doc[:copyright]) %>
 <% end %>

--- a/app/views/apipie/apipies/resource.html.erb
+++ b/app/views/apipie/apipies/resource.html.erb
@@ -63,5 +63,5 @@
 </div>
 
 <% unless content_for(:apipie_footer) == @doc[:copyright] %>
-  <%= provide :apipie_footer, raw(@doc[:copyright]) %>
+  <%= content_for :apipie_footer, raw(@doc[:copyright]) %>
 <% end %>

--- a/app/views/apipie/apipies/static.html.erb
+++ b/app/views/apipie/apipies/static.html.erb
@@ -98,5 +98,5 @@
 <% end %>
 
 <% unless content_for(:apipie_footer) == @doc[:copyright] %>
-  <%= provide :apipie_footer, raw(@doc[:copyright]) %>
+  <%= content_for :apipie_footer, raw(@doc[:copyright]) %>
 <% end %>


### PR DESCRIPTION
Copyright appear multiple times in docs generated via rake task (`apipie:static`).
Added check for `apipie_footer` content before add new content
