### PR TITLE
Lets users configure the doc page link extension to achieve 'clean' URLs...

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -549,6 +549,10 @@ authenticate
 show_all_examples
   Set this to true to set show_in_doc=1 in all recorded examples
 
+link_extension
+  The extension to use for API pages ('.html' by default).  Link extensions
+  in static API docs cannot be changed from '.html'. 
+
 Example:
 
 .. code:: ruby

--- a/app/controllers/apipie/apipies_controller.rb
+++ b/app/controllers/apipie/apipies_controller.rb
@@ -43,6 +43,7 @@ module Apipie
 
           @versions = Apipie.available_versions
           @doc = @doc[:docs]
+          @doc[:link_extension] = Apipie.configuration.link_extension
           if @doc[:resources].blank?
             render "getting_started" and return
           end

--- a/app/views/apipie/apipies/apipie_404.html.erb
+++ b/app/views/apipie/apipies/apipie_404.html.erb
@@ -10,5 +10,5 @@
 </h1>
 
 <% if @doc %>
-  Try going to <a href='<%= @doc[:doc_url] %>.html'><%= @doc[:name] %> API documentation homepage</a>
+  Try going to <a href='<%= @doc[:doc_url] %><%= @doc[:link_extension] %>'><%= @doc[:name] %> API documentation homepage</a>
 <% end %>

--- a/app/views/apipie/apipies/index.html.erb
+++ b/app/views/apipie/apipies/index.html.erb
@@ -1,5 +1,5 @@
 <ul class='breadcrumb'>
-  <li class='active'><a href='<%= @doc[:doc_url] %>.html'><%= @doc[:name] %> <%= @doc[:resources].values.first[:version] %></a></li>
+  <li class='active'><a href='<%= @doc[:doc_url] %><%= @doc[:link_extension] %>'><%= @doc[:name] %> <%= @doc[:resources].values.first[:version] %></a></li>
   <% if @versions && @versions.size > 1 %>
   <li class='pull-right'>
     <%= @versions.collect { |v| link_to v, Apipie.full_url(v) }.join(' / ').html_safe %>
@@ -13,7 +13,7 @@
 
 <% @doc[:resources].sort_by(&:first).each do |key, api| %>
   <h2>
-    <a href='<%= api[:doc_url] %>.html'>
+    <a href='<%= api[:doc_url] %><%= @doc[:link_extension] %>'>
       <%= api[:name] %>
     </a><br>
     <small><%= api[:short_description] %></small>
@@ -29,7 +29,7 @@
       <% api[:methods].each do |m| %>
         <% m[:apis].each do |a| %>
           <tr>
-            <td><a href='<%= m[:doc_url] %>.html'><%= a[:http_method] %> <%= a[:api_url] %></a></td>
+            <td><a href='<%= m[:doc_url] %><%= @doc[:link_extension] %>'><%= a[:http_method] %> <%= a[:api_url] %></a></td>
             <td width='60%'><%= a[:short_description] %></td>
           </tr>
         <% end %>

--- a/app/views/apipie/apipies/method.html.erb
+++ b/app/views/apipie/apipies/method.html.erb
@@ -1,10 +1,10 @@
 <ul class='breadcrumb'>
   <li>
-    <a href='<%= @doc[:doc_url] %>.html'><%= @doc[:name] %> <%= @resource[:version] %></a>
+    <a href='<%= @doc[:doc_url] %><%= @doc[:link_extension] %>'><%= @doc[:name] %> <%= @resource[:version] %></a>
     <span class='divider'>/</span>
   </li>
   <li>
-    <a href='<%= @resource[:doc_url] %>.html'>
+    <a href='<%= @resource[:doc_url] %><%= @doc[:link_extension] %>'>
       <%= @resource[:name] %>
       <% if @resource[:version] %><% end %>
     </a>
@@ -24,7 +24,7 @@
 
 <div>
   <% unless @method[:see].empty? %>
-    Also see <%= @method[:see].map { |s| link_to(s[:description], "#{s[:link]}.html") }.to_sentence.html_safe %>.
+    Also see <%= @method[:see].map { |s| link_to(s[:description], "#{s[:link]}#{@doc[:link_extension]}") }.to_sentence.html_safe %>.
   <% end %>
 
   <%= render(:partial => "method_detail", :locals => {:method => @method, :h_level => 2}) %>

--- a/app/views/apipie/apipies/resource.html.erb
+++ b/app/views/apipie/apipies/resource.html.erb
@@ -1,6 +1,6 @@
 <ul class='breadcrumb'>
   <li>
-    <a href='<%= @doc[:doc_url] %>.html'><%= @doc[:name] %> <%= @resource[:version] %></a>
+    <a href='<%= @doc[:doc_url] %><%= @doc[:link_extension] %>'><%= @doc[:name] %> <%= @resource[:version] %></a>
     <span class='divider'>/</span>
   </li>
   <li class='active'>
@@ -36,7 +36,7 @@
   <% @resource[:methods].each do |m| %>
     <hr>
     <div class='pull-right small'>
-      <a href='<%= m[:doc_url] %>.html'> >>> </a>
+      <a href='<%= m[:doc_url] %><%= @doc[:link_extension] %>'> >>> </a>
     </div>
     <div>
       <% m[:apis].each do |api| %>
@@ -53,7 +53,7 @@
     </div>
 
     <% unless m[:see].empty? %>
-      Also see <%= m[:see].map { |s| link_to(s[:description], "#{s[:link]}.html") }.to_sentence.html_safe %>.
+      Also see <%= m[:see].map { |s| link_to(s[:description], "#{s[:link]}#{@doc[:link_extension]}") }.to_sentence.html_safe %>.
     <% end %>
 
     <div id='description-<%= m[:name] %>' class='collapse accordion-body'>

--- a/lib/apipie/configuration.rb
+++ b/lib/apipie/configuration.rb
@@ -5,7 +5,8 @@ module Apipie
       :api_base_url, :doc_base_url, :required_by_default, :layout,
       :default_version, :debug, :version_in_url, :namespaced_resources,
       :validate, :validate_value, :validate_presence, :authenticate, :doc_path,
-      :show_all_examples, :process_params, :update_checksum, :checksum_path
+      :show_all_examples, :process_params, :update_checksum, :checksum_path,
+      :link_extension
 
     alias_method :validate?, :validate
     alias_method :required_by_default?, :required_by_default
@@ -130,6 +131,7 @@ module Apipie
       @process_params = false
       @checksum_path = [@doc_base_url, '/api/']
       @update_checksum = false
+      @link_extension = ".html"
     end
   end
 end

--- a/lib/tasks/apipie.rake
+++ b/lib/tasks/apipie.rake
@@ -25,6 +25,7 @@ namespace :apipie do
       Apipie.configuration.version_in_url = false
       Apipie.url_prefix = "./#{subdir}"
       doc = Apipie.to_json(args[:version])
+      doc[:docs][:link_extension] = '.html'
       generate_one_page(out, doc)
       generate_plain_page(out, doc)
       generate_index_page(out, doc)

--- a/spec/dummy/config/initializers/apipie.rb
+++ b/spec/dummy/config/initializers/apipie.rb
@@ -64,6 +64,10 @@ Apipie.configure do |config|
   # specify disqus site shortname to show discusion on each page
   # to show it in custom layout, use `render 'disqus' if Apipie.configuration.use_disqus?`
   # config.disqus_shortname = 'paveltest'
+
+  # Hide '.html' extensions.  Note that '.html' extensions are forced
+  # when generating static documentation
+  # config.link_extension = ""
 end
 
 


### PR DESCRIPTION
Lets users configure the doc page link extension to achieve cleaner URLs, e.g. '/api/v1/users/create' instead of '/api/v1/users/create.html'.

Without any configuration changes, Apipie will do exactly what it did before (so this shouldn't hurt anyone's deployment).

If `config.link_extension` is set to `""` in an Apipie initializer, API doc URLs will not have `.html` at the end.  

Regardless of this configuration setting, staticly-generated API pages (from `rake apipie:static`) will still use the `.html` extension. 

Addresses #216
