### PR TITLE
Test against ruby 2.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.0
+  - 2.1.1
 gemfile:
   - Gemfile.rails30
   - Gemfile.rails32


### PR DESCRIPTION
Ruby 2.1.1 is the latest stable and this should also fix: https://travis-ci.org/Apipie/apipie-rails/builds/24081433
