### PR TITLE
New configuration option to always record examples.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -554,7 +554,7 @@ show_all_examples
 
 link_extension
   The extension to use for API pages ('.html' by default).  Link extensions
-  in static API docs cannot be changed from '.html'. 
+  in static API docs cannot be changed from '.html'.
 
 Example:
 
@@ -940,7 +940,7 @@ of information is already included in this tests, it just needs to be
 extracted somehow. Luckily, Apipie provides such a feature.
 
 When running the tests, set the ``APIPIE_RECORD=params`` environment
-variable. You can either use it with functional tests
+variable or call ``Apipie.record('params')`` from specs starter. You can either use it with functional tests
 
 .. code::
 
@@ -962,7 +962,7 @@ Examples Recording
 
 You can also use the tests to generate up-to-date examples for your
 code. Similarly to the bootstrapping, you can use it with functional
-tests or a running server, setting ``APIPIE_RECORD=examples``
+tests or a running server, setting ``APIPIE_RECORD=examples`` or by calling ``Apipie.record('examples')`` in your specs starter.
 
 .. code::
 

--- a/lib/apipie/apipie_module.rb
+++ b/lib/apipie/apipie_module.rb
@@ -59,4 +59,7 @@ module Apipie
     version && self.configuration.api_base_url.has_key?(version)
   end
 
+  def self.record(record)
+    Apipie::Extractor.start record
+  end
 end

--- a/lib/apipie/configuration.rb
+++ b/lib/apipie/configuration.rb
@@ -6,7 +6,7 @@ module Apipie
       :default_version, :debug, :version_in_url, :namespaced_resources,
       :validate, :validate_value, :validate_presence, :authenticate, :doc_path,
       :show_all_examples, :process_params, :update_checksum, :checksum_path,
-      :link_extension
+      :link_extension, :record
 
     alias_method :validate?, :validate
     alias_method :required_by_default?, :required_by_default
@@ -141,6 +141,7 @@ module Apipie
       @checksum_path = [@doc_base_url, '/api/']
       @update_checksum = false
       @link_extension = ".html"
+      @record = false
     end
   end
 end

--- a/lib/apipie/extractor/recorder.rb
+++ b/lib/apipie/extractor/recorder.rb
@@ -89,8 +89,10 @@ module Apipie
         end
 
         def call(env)
-          analyze(env) do
-            @app.call(env)
+          if Apipie.configuration.record
+            analyze(env) do
+              @app.call(env)
+            end
           end
         end
 
@@ -112,15 +114,15 @@ module Apipie
 
         def process_with_api_recording(*args) # action, parameters = nil, session = nil, flash = nil, http_method = 'GET')
           ret = process_without_api_recording(*args)
-          Apipie::Extractor.call_recorder.analyze_functional_test(self)
-          Apipie::Extractor.call_finished
+          if Apipie.configuration.record
+            Apipie::Extractor.call_recorder.analyze_functional_test(self)
+            Apipie::Extractor.call_finished
+          end
           ret
         ensure
           Apipie::Extractor.clean_call_recorder
         end
       end
-
     end
-
   end
 end


### PR DESCRIPTION
In current project I'm working on, I've stumbled into the problem not being able to start examples/params recording from `spec_helper.rb`. I want my examples to be always up-to-date without the burden of remembering to run tests with `APIPIE_RECORD` env.

This PR adds method `Apipie.record` which can be used in `spec_helper.rb` or `test_helper.rb` to start examples recording without using `APIPIE_RECORD` env.
