### PR TITLE
Tests for middleware.

### DIFF
--- a/lib/apipie/extractor/recorder.rb
+++ b/lib/apipie/extractor/recorder.rb
@@ -93,6 +93,8 @@ module Apipie
             analyze(env) do
               @app.call(env)
             end
+          else
+            @app.call(env)
           end
         end
 

--- a/spec/lib/extractor/middleware_spec.rb
+++ b/spec/lib/extractor/middleware_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe Apipie::Extractor::Recorder::Middleware do
+  let(:app) { ->(env) { [200, env, "app"] } }
+  let(:stack) { Apipie::Extractor::Recorder::Middleware.new(app) }
+  let(:request) { Rack::MockRequest.new(stack) }
+  let(:response) { request.get('/') }
+
+  it 'correctly process request without recording' do
+    expect(stack).not_to receive(:analyze)
+    response
+  end
+
+  it "analyze request if recording is set" do
+    Apipie.configuration.record = true
+    expect(Apipie::Extractor.call_recorder).to receive(:analyse_env)
+    expect(Apipie::Extractor.call_recorder).to receive(:analyse_response)
+    expect(Apipie::Extractor).to receive(:clean_call_recorder)
+    response
+  end
+end


### PR DESCRIPTION
Currently there was nothing which would check the request going through rack so unless you ran integration tests everything would seem to work. 

Fix in `lib/apipie/extractor/recorder.rb` for inproper return value in call method if recording is disabled.
