### PR TITLE
Fix loc typo in view

### DIFF
--- a/app/views/apipie/apipies/_method_detail.erb
+++ b/app/views/apipie/apipies/_method_detail.erb
@@ -35,7 +35,7 @@
   <table class='table'>
     <thead>
       <tr>
-        <th><%= t('aapipie.param_name') %></th>
+        <th><%= t('apipie.param_name') %></th>
         <th><%= t('apipie.description') %></th>
       </tr>
     </thead>


### PR DESCRIPTION
It was just a typo, but it causes 500 errors..
