### PR TITLE
Syntax Error fix in apipie_404.html.erb

### DIFF
--- a/app/views/apipie/apipies/apipie_404.html.erb
+++ b/app/views/apipie/apipies/apipie_404.html.erb
@@ -5,13 +5,13 @@
     <%= t('apipie.resource_not_found_html', :resource => "<code>#{params[:resource]}</code>") %>
   <% else %>
     <%= t('apipie.method_not_found_html', :resource => "<code>#{params[:resource]}</code>",
-        :method => "<code>#{params[:resource]}</code>" %>
+        :method => "<code>#{params[:resource]}</code>") %>
   <% end %>
   </small>
 </h1>
 
 <% if @doc %>
-  <%= t('apipie.goto_homepage_html', :href = link_to(
+  <%= t('apipie.goto_homepage_html', :href => link_to(
     t('apipie.goto_homepage_href', :app_name => @doc[:name]),
     File.join(@doc[:doc_url], @doc[:link_extension]))) %>
 <% end %>


### PR DESCRIPTION
The app wasn't displaying the '/apipie' path due to a syntax error in one of the view.
Added the missing parentheses and fixed ":href = link_to(..)" to ":href => link_to(..).
