### PR TITLE
Supply :validations parameter for simple inclusion

### DIFF
--- a/app/views/apipie/apipies/_params.html.erb
+++ b/app/views/apipie/apipies/_params.html.erb
@@ -15,17 +15,23 @@
     </td>
     <td>
       <%= param[:description].html_safe %>
-      <% unless param[:validator].blank? %>
-        <br>
-        Value: <%= param[:validator] %>
-      <% end %>
+      <%- if param[:validations].present? || param[:validator].present? %>
+        <p><strong>Validations:</strong></p>
+        <ul>
+          <%- if param[:validator].present? %>
+            <li><%= param[:validator] %></li>
+          <%- end %>
+          <%- param[:validations].each do |item| %>
+            <li><%= item.html_safe %></li>
+          <%- end %>
+        </ul>
+      <%- end %>
 
       <% unless param[:metadata].blank? %>
         <br>
         Metadata:
         <%= render(:partial => "metadata", :locals => {:meta => param[:metadata]}) %>
       <% end %>
-
     </td>
 
   </tr>

--- a/lib/apipie/param_description.rb
+++ b/lib/apipie/param_description.rb
@@ -8,7 +8,7 @@ module Apipie
   # validator - Validator::BaseValidator subclass
   class ParamDescription
 
-    attr_reader :method_description, :name, :desc, :allow_nil, :validator, :options, :metadata, :show, :as
+    attr_reader :method_description, :name, :desc, :allow_nil, :validator, :options, :metadata, :show, :as, :validations
     attr_accessor :parent, :required
 
     def self.from_dsl_data(method_description, args)
@@ -64,6 +64,8 @@ module Apipie
         @validator = Validator::BaseValidator.find(self, validator, @options, block)
         raise "Validator for #{validator} not found." unless @validator
       end
+
+      @validations = Array(options[:validations]).map {|v| concern_subst(Apipie.markup_to_html(v)) }
     end
 
     def validate(value)
@@ -109,7 +111,8 @@ module Apipie
                :validator => validator.to_s,
                :expected_type => validator.expected_type,
                :metadata => metadata,
-               :show => show }
+               :show => show,
+               :validations => validations }
       if sub_params = validator.params_ordered
         hash[:params] = sub_params.map { |p| p.to_json(lang)}
       end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -224,7 +224,8 @@ describe UsersController do
                               :allow_nil => true,
                               :metadata => nil,
                               :show => true,
-                              :expected_type => "hash")
+                              :expected_type => "hash",
+                              :validations => [])
       end
 
       it "should allow nil when allow_nil is set to true" do

--- a/spec/lib/param_description_spec.rb
+++ b/spec/lib/param_description_spec.rb
@@ -79,6 +79,21 @@ describe Apipie::ParamDescription do
     end
   end
 
+  describe "manual validation text" do
+    it "should allow manual text" do
+      param = Apipie::ParamDescription.new(method_desc, :hidden_param, nil, :validations => "must be foo")
+
+      param.validations.should include("\n<p>must be foo</p>\n")
+    end
+
+    it "should allow multiple items" do
+      param = Apipie::ParamDescription.new(method_desc, :hidden_param, nil, :validations => ["> 0", "< 5"])
+
+      param.validations.should include("\n<p>&gt; 0</p>\n")
+      param.validations.should include("\n<p>&lt; 5</p>\n")
+    end
+  end
+
   describe "validator selection" do
 
     it "should allow nil validator" do


### PR DESCRIPTION
This allows the user to outline some purely textual validation text for
inclusion into the api documentation. Useful when clarifying a minor
point of the "type" validator that doesn't warrant a custom validate.

For example, specifying that an +Integer+ parameter must be > 0.

This change also provides more visual weight to the
validator/validations section of the parameter documentation.