### PR TITLE
Prevent rspec 3 from being used. It is not compatible.

### DIFF
--- a/apipie-rails.gemspec
+++ b/apipie-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 3.0.10"
   s.add_dependency 'json'
-  s.add_development_dependency "rspec-rails"
+  s.add_development_dependency "rspec-rails", "~> 2.14.2"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "minitest"
   s.add_development_dependency "maruku"


### PR DESCRIPTION
Add restriction to prevent rspec 3 from being used. When rspec 3 is used, the build does not pass.
