### PR TITLE
Add more options to apipie:cache

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -979,6 +979,10 @@ When you want to avoid any unnecessary computation in production mode,
 you can generate a cache with ``rake apipie:cache`` and configure the
 app to use it in production with ``config.use_cache = Rails.env.production?``
 
+If, for some complex casese, you need to generate/re-generate just part of the cache
+use ``rake apipie:cache cache_part=index`` resp. ``rake apipie:cache cache_part=resources``
+To generate it to different location for further processing use ``rake apipie:cache OUT=/tmp/apipie_cache``.
+
 ===================
  JSON checksums
 ===================

--- a/app/views/apipie/apipies/index.html.erb
+++ b/app/views/apipie/apipies/index.html.erb
@@ -1,5 +1,5 @@
 <ul class='breadcrumb'>
-  <li class='active'><a href='<%= @doc[:doc_url] %><%= @doc[:link_extension] %>'><%= @doc[:name] %> <%= @doc[:resources].values.first[:version] %></a></li>
+  <li class='active'><a href='<%= @doc[:doc_url] %><%= @doc[:link_extension] %>'><%= @doc[:name] %> <%= @doc[:resources].values.first && @doc[:resources].values.first[:version] %></a></li>
   <%= render(:partial => "languages", :locals => {:doc_url => @doc[:doc_url]}) %>
   <% if @versions && @versions.size > 1 %>
   <li class='pull-right'>


### PR DESCRIPTION
This patch adds `cache_part=[index|resources]` and `OUT=/some/dir` options to rake task `apipie:cache`.
In our enviroment the API is quite big and with the localization it takes a lot of time to generate the cache. With these options I can pre-generate part of the cache during the build time to save some time during installation.
