### PR TITLE
reduced rails dependency to development only

### DIFF
--- a/apipie-rails.gemspec
+++ b/apipie-rails.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_dependency "rails", ">= 3.0.10"
+  s.add_development_dependency "rails", ">= 3.0.10"
   s.add_dependency 'json'
   s.add_development_dependency "rspec-rails", "~> 2.14.2"
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
dependency on rails is unnecessary and causes the inclusion of activerecord which we don't use. Rails dependency for test and development is sufficient.
