### PR TITLE
Add ability to pass additional options to apipie route

### DIFF
--- a/lib/apipie/routing.rb
+++ b/lib/apipie/routing.rb
@@ -1,11 +1,11 @@
 module Apipie
   module Routing
     module MapperExtensions
-      def apipie
+      def apipie(options = {})
         namespace "apipie", :path => Apipie.configuration.doc_base_url do
           get 'apipie_checksum', :to => "apipies#apipie_checksum", :format => "json"
           constraints(:version => /[^\/]+/, :resource => /[^\/]+/, :method => /[^\/]+/) do
-            get("(:version)/(:resource)/(:method)" => "apipies#index", :as => :apipie)
+            get(options.reverse_merge("(:version)/(:resource)/(:method)" => "apipies#index", :as => :apipie))
           end
         end
       end


### PR DESCRIPTION
Hi, can we add ability to pass additional options to apipie route?
In my case I'd like to add `constraints` like:

``` ruby
Test::Application.routes.draw do
  apipie constraints: DeveloperConstraint.new
end

class DeveloperConstraint
  def matches?(request)
    request.env['warden'].authenticate? && request.env['warden'].user.has_role?(:developer)
  end
end
```
