### PR TITLE
Restore Ruby 1.8.7 compatibility with lambda styles etc.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.1
@@ -7,3 +8,9 @@ gemfile:
   - Gemfile.rails32
   - Gemfile.rails40
   - Gemfile.rails41
+matrix:
+  exclude:
+    - rvm: 1.8.7
+      gemfile: Gemfile.rails40
+    - rvm: 1.8.7
+      gemfile: Gemfile.rails41

--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -163,7 +163,7 @@ module Apipie
       end
 
       def validate(values)
-        return false unless process_value(values).respond_to?(:each)
+        return false unless process_value(values).respond_to?(:each) && !process_value(values).is_a?(String)
         process_value(values).all? { |v| validate_item(v)}
       end
 
@@ -175,7 +175,7 @@ module Apipie
         "Must be an array of #{items}"
       end
 
-      def self.build(param_description, argument, options={}, block)
+      def self.build(param_description, argument, options, block)
         if argument == Array && !block.is_a?(Proc)
           self.new(param_description, argument, options)
         end

--- a/spec/lib/extractor/middleware_spec.rb
+++ b/spec/lib/extractor/middleware_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe Apipie::Extractor::Recorder::Middleware do
-  let(:app) { ->(env) { [200, env, "app"] } }
+  let(:app) { lambda { |env| [200, env, "app"] } }
   let(:stack) { Apipie::Extractor::Recorder::Middleware.new(app) }
   let(:request) { Rack::MockRequest.new(stack) }
   let(:response) { request.get('/') }

--- a/spec/lib/method_description_spec.rb
+++ b/spec/lib/method_description_spec.rb
@@ -32,7 +32,7 @@ describe Apipie::MethodDescription do
     end
 
     it "should return the deprecated flag when provided" do
-      dsl_data[:api_args] = [[:GET, "/foo/bar", "description", :deprecated => true]]
+      dsl_data[:api_args] = [[:GET, "/foo/bar", "description", {:deprecated => true}]]
       method = Apipie::MethodDescription.new(:a, @resource, dsl_data)
       method.method_apis_to_json.first[:deprecated].should == true
     end

--- a/spec/lib/validators/array_validator_spec.rb
+++ b/spec/lib/validators/array_validator_spec.rb
@@ -24,7 +24,7 @@ module Apipie::Validator
     end
 
     context "with a constraint on items type" do
-      let(:validator) { ArrayValidator.new(param_desc, Array, of: String) }
+      let(:validator) { ArrayValidator.new(param_desc, Array, :of => String) }
 
       it "accepts array of specified type" do
         expect(validator.validate(['string1', 'string2'])).to eq(true)
@@ -40,7 +40,7 @@ module Apipie::Validator
     end
 
     context "with a constraint on items value" do
-      let(:validator) { ArrayValidator.new(param_desc, Array, in: [42, 'string', true]) }
+      let(:validator) { ArrayValidator.new(param_desc, Array, :in => [42, 'string', true]) }
 
       it "accepts array of valid values" do
         expect(validator.validate([42, 'string'])).to eq(true)
@@ -55,7 +55,7 @@ module Apipie::Validator
       end
 
       it "accepts a proc as list of valid values" do
-        validator = ArrayValidator.new(param_desc, Array, in: -> { [42, 'string', true] })
+        validator = ArrayValidator.new(param_desc, Array, :in => lambda { [42, 'string', true] })
         expect(validator.validate([42, 'string'])).to eq(true)
         expect(validator.validate([42, 'string', 'foo'])).to eq(false)
       end


### PR DESCRIPTION
You'll hate me for this, I know, but 0.2.3 broke 1.8 compatibility in lib/.  spec/ had a couple of issues already but otherwise 0.2.2 worked great, despite 87b2158.
