### PR TITLE
Add ability to markup validator description

### DIFF
--- a/app/views/apipie/apipies/_params.html.erb
+++ b/app/views/apipie/apipies/_params.html.erb
@@ -17,7 +17,7 @@
       <%= param[:description].html_safe %>
       <% unless param[:validator].blank? %>
         <br>
-        Value: <%= param[:validator] %>
+        Value: <%= Apipie.markup_to_html(param[:validator]).html_safe %>
       <% end %>
 
       <% unless param[:metadata].blank? %>

--- a/app/views/apipie/apipies/_params_plain.html.erb
+++ b/app/views/apipie/apipies/_params_plain.html.erb
@@ -10,7 +10,7 @@
         <%= param[:required] ? t('apipie.required') : t('apipie.optional') %>
         <%= param[:allow_nil] ? ', '+t('apipie.nil_allowed') : '' %>
         <% if param[:validator] %>
-          [ <%= param[:validator] %> ]
+          [ <%= Apipie.markup_to_html(param[:validator]).html_safe %> ]
         <% end %>
       </small>
       <%= param[:description].html_safe %>


### PR DESCRIPTION
Hi!
I'm using `config.markup = Apipie::Markup::Markdown.new` and I have my custom validator:

``` ruby
class Apipie::Validator::StringQueryValidator < Apipie::Validator::BaseValidator
  def initialize(param_description, argument, options)
    super(param_description)
  end

  def validate(value)
    !!(value =~ /^[^&*\/\^]+$/)
  end

  def self.build(param_description, argument, options, block)
    if options[:validator] == :query
      self.new(param_description, argument, options)
    end
  end

  def description
    'Must have any characters except: `/` `&` `^` `*`'
  end
end
```

I'd like to make this description highlighted :smiley_cat:  
