### PR TITLE
Don't specify protocol in Disqus script tag src

### DIFF
--- a/app/views/apipie/apipies/_disqus.html.erb
+++ b/app/views/apipie/apipies/_disqus.html.erb
@@ -3,7 +3,7 @@
     var disqus_shortname = "<%= Apipie.configuration.disqus_shortname %>";
     (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
 </script>


### PR DESCRIPTION
Allows Disqus to load in http and secure https environments
