### PR TITLE
Replace redcarpet with maruku

### DIFF
--- a/lib/apipie/markup.rb
+++ b/lib/apipie/markup.rb
@@ -27,7 +27,8 @@ module Apipie
       end
 
       def to_html(text)
-        markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: true, no_intra_emphasis: true)
+        markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML,
+          fenced_code_blocks: true, autolink: true, no_intra_emphasis: true)
         markdown.render(text)
       end
 


### PR DESCRIPTION
2 reasons:
1. redcarpet is faster then maruku (also maruku looks like a dead lib)
2. I want autolinks and triple backticked code blocks in my documentation when using markdown

Also, please update `Markup` wiki section and `s/Maruku/Redcarpet` in it

Cheers! 
