### PR TITLE
Fixes ConcurrencyError

### DIFF
--- a/lib/apipie/error_description.rb
+++ b/lib/apipie/error_description.rb
@@ -13,7 +13,7 @@ module Apipie
 
     def initialize(code_or_options, desc=nil, options={})
       if code_or_options.is_a? Hash
-        code_or_options.symbolize_keys!
+        code_or_options = code_or_options.symbolize_keys
         @code = code_or_options[:code]
         @metadata = code_or_options[:meta]
         @description = code_or_options[:desc] || code_or_options[:description]

--- a/lib/apipie/param_description.rb
+++ b/lib/apipie/param_description.rb
@@ -31,10 +31,8 @@ module Apipie
         raise ArgumentError.new("param description: expected description or options as 3rd parameter")
       end
 
-      options.symbolize_keys!
-
       # we save options to know what was passed in DSL
-      @options = options
+      @options = options.symbolize_keys
       if @options[:param_group]
         @from_concern = @options[:param_group][:from_concern]
       end


### PR DESCRIPTION
We run our app servers in Puma under JRuby. Sometimes an app server gets into a bad state, and starts throwing the following error from Apipie:

```
ConcurrencyError (Detected invalid hash contents due to unsynchronized modifications with concurrent users)
```

We have not been able to consistently reproduce this issue, but it appears that several requests executing on the same controller action at the same time cause the options hash to be destructively modified concurrently. From that point forward, all API calls fail.

We believe the attached patch resolves the issue by avoiding destructive modifications.
