### PR TITLE
Proper url_prefix when doc_base_url has multiple folders

### DIFF
--- a/lib/tasks/apipie.rake
+++ b/lib/tasks/apipie.rake
@@ -68,6 +68,8 @@ namespace :apipie do
         puts "#{Time.now} | Processing docs for #{lang}"
         cache_dir = ENV["OUT"] || Apipie.configuration.cache_dir
         subdir = Apipie.configuration.doc_base_url.sub(/\A\//,"")
+        subdir_levels = subdir.split('/').length
+        subdir_traversal_prefix = '../' * subdir_levels
         file_base = File.join(cache_dir, Apipie.configuration.doc_base_url)
 
         if generate_index
@@ -78,15 +80,15 @@ namespace :apipie do
         end
         Apipie.available_versions.each do |version|
           file_base_version = File.join(file_base, version)
-          Apipie.url_prefix = "../#{subdir}"
+          Apipie.url_prefix = "#{subdir_traversal_prefix}#{subdir}"
           doc = Apipie.to_json(version, nil, nil, lang)
           doc[:docs][:link_extension] = (lang ? ".#{lang}.html" : ".html")
 
           generate_index_page(file_base_version, doc, true, true, lang) if generate_index
           if generate_resources
-            Apipie.url_prefix = "../../#{subdir}"
+            Apipie.url_prefix = "../#{subdir_traversal_prefix}#{subdir}"
             generate_resource_pages(version, file_base_version, doc, true, lang)
-            Apipie.url_prefix = "../../../#{subdir}"
+            Apipie.url_prefix = "../../#{subdir_traversal_prefix}#{subdir}"
             generate_method_pages(version, file_base_version, doc, true, lang)
           end
         end


### PR DESCRIPTION
The assignments to `Apipie.url_prefix` assume that the doc_base_url is one folder. This PR corrects assignments to `Apipie.url_prefix` with the proper traversal to the documentation root.
