### PR TITLE
Fix UploadedFile encoding error from to_json

### DIFF
--- a/lib/apipie/extractor/writer.rb
+++ b/lib/apipie/extractor/writer.rb
@@ -79,12 +79,18 @@ module Apipie
           next unless call.has_key?(k)
           ordered_call[k] = case call[k]
                        when ActiveSupport::HashWithIndifferentAccess
-                         JSON.parse(call[k].to_json) # to_hash doesn't work recursively and I'm too lazy to write the recursion:)
+                         parse_hash(call[k])
                        else
                          call[k]
                        end
         end
         return ordered_call
+      end
+
+      def parse_hash(hash)
+        JSON.parse(call[k].to_json)
+      rescue
+        JSON.parse(call[k].to_json)
       end
 
       def load_recorded_examples


### PR DESCRIPTION
When I'm trying to use an example where I serialize a PDF I get the following error:

```
/Users/Blake/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/activesupport-4.1.6/lib/active_support/core_ext/object/json.rb:34:in `encode': "\xE2" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)`
```

Oddly enough this only happens on the first time you try to call `to_json`.

I know it's not ideal, but this is definitely a temporary and quick fix until I or someone else has time to implement a better fix.