### PR TITLE
Fix NilClass error when controller has no api version namespace

### DIFF
--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -297,7 +297,8 @@ module Apipie
       elsif Apipie.configuration.namespaced_resources? && klass.respond_to?(:controller_path)
         return nil if klass == ActionController::Base
         path = klass.controller_path
-        path.gsub(version_prefix(klass), "").gsub("/", "-")
+        path.gsub!(prefix, "") if (prefix = version_prefix(klass)) && prefix != "/"
+        path.gsub("/", "-")
       elsif klass.respond_to?(:controller_name)
         return nil if klass == ActionController::Base
         klass.controller_name
@@ -341,7 +342,7 @@ module Apipie
     def version_prefix(klass)
       version = controller_versions(klass).first
       base_url = get_base_url(version)
-      return "/" if base_url.nil?
+      return "/" if base_url.empty?
       base_url[1..-1] + "/"
     end
 


### PR DESCRIPTION
How to repeat the error:
1. Set `config.namespaced_resources = true` in apipie.rb
2. Name your controllers without version namespace, f.e. `class Publisher::AccountController < ApplicationController`
3. When trying to access ApiPie doc, this is the error you'll get:

```
NoMethodError - undefined method `+' for nil:NilClass:
  apipie-rails (0.2.6) lib/apipie/application.rb:345:in `version_prefix'
  apipie-rails (0.2.6) lib/apipie/application.rb:300:in `get_resource_name'
  apipie-rails (0.2.6) lib/apipie/application.rb:41:in `block in define_method_description'
  apipie-rails (0.2.6) lib/apipie/application.rb:40:in `define_method_description'
  apipie-rails (0.2.6) lib/apipie/apipie_module.rb:18:in `method_missing'
  apipie-rails (0.2.6) lib/apipie/dsl_definition.rb:347:in `method_added'
  app/controllers/publisher/account_controller.rb:3:in `<class:AccountController>'
```

This fixes it.
