### PR TITLE
Eliminate to_sym calls on user input

### DIFF
--- a/lib/apipie/dsl_definition.rb
+++ b/lib/apipie/dsl_definition.rb
@@ -218,7 +218,7 @@ module Apipie
               # Only allow params passed in that are defined keys in the api
               # Auto skip the default params (format, controller, action)
               if Apipie.configuration.validate_key?
-                params.reject{|k,_| [:format, :controller, :action].include?(k.to_sym) }.each_key do |param|
+                params.reject{|k,_| %w[format controller action].include?(k.to_s) }.each_key do |param|
                   # params allowed
                   raise UnknownParam.new(param) if method_params.select {|_,p| p.name.to_s == param.to_s}.empty?
                 end


### PR DESCRIPTION
Luckily, this changes were note release yet.
