### PR TITLE
Fix ordering of registering the StaticDispatcher middleware

### DIFF
--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -9,8 +9,8 @@ module Apipie
 
     # we need engine just for serving static assets
     class Engine < Rails::Engine
-      initializer "static assets" do |app|
-        app.middleware.use ::Apipie::StaticDispatcher, "#{root}/app/public", Apipie.configuration.doc_base_url
+      initializer "static assets", :before => :build_middleware_stack do |app|
+        app.middleware.use ::Apipie::StaticDispatcher, "#{root}/app/public"
       end
     end
 

--- a/lib/apipie/static_dispatcher.rb
+++ b/lib/apipie/static_dispatcher.rb
@@ -45,13 +45,13 @@ module Apipie
   class StaticDispatcher
     # Dispatches the static files. Similar to ActionDispatch::Static, but
     # it supports different baseurl configurations
-    def initialize(app, path, baseurl)
+    def initialize(app, path)
       @app = app
-      @baseurl = baseurl
       @file_handler = Apipie::FileHandler.new(path)
     end
 
     def call(env)
+      @baseurl ||= Apipie.configuration.doc_base_url
       case env['REQUEST_METHOD']
       when 'GET', 'HEAD'
         path = env['PATH_INFO'].sub("#{@baseurl}/","/apipie/").chomp('/')


### PR DESCRIPTION
There was a chance that the registration of the StaticDispatcher was called
after the middleware stack was already initialized. Also not using the
Apipie.configuration at that point, as the rails initializer setting the
configuration might not be run yet by that time.