### PR TITLE
The Examples formatting was using string concatenation, I needed more control

### DIFF
--- a/app/helpers/apipie_helper.rb
+++ b/app/helpers/apipie_helper.rb
@@ -6,4 +6,13 @@ module ApipieHelper
     end
   end
 
+  def format_example_data(data)
+    case data
+    when Array, Hash
+      JSON.pretty_generate(data).gsub(/: \[\s*\]/,": []").gsub(/\{\s*\}/,"{}")
+    else
+      data
+    end
+  end
+
 end

--- a/app/views/apipie/apipies/_example.html.erb
+++ b/app/views/apipie/apipies/_example.html.erb
@@ -1,0 +1,12 @@
+<% if example["title"] && example["title"].present? %>
+<%= example["title"] %>
+<% end %>
+<%= example["verb"] -%> <%= example["path"] -%>
+<% if example["request_data"] -%>
+<%= format_example_data(example["request_data"]).to_s %>
+<% end %>
+<%= example["code"] %>
+<% if example["response_data"] -%>
+<%= format_example_data(example["response_data"]).to_s %>
+<% end %>
+

--- a/app/views/apipie/apipies/_method_detail.erb
+++ b/app/views/apipie/apipies/_method_detail.erb
@@ -30,6 +30,13 @@
   <% end %>
 <% end %>
 
+<% unless method[:examples_data].blank? %>
+  <%= heading(t('apipie.examples'), h_level) %>
+  <% method[:examples].each do |example| %>
+    <%= render(:partial => "example", :locals => {:example => example}) %>
+  <% end %>
+<% end %>
+
 <% unless method[:params].blank? %>
   <%= heading(t('apipie.params'), h_level) %>
   <table class='table'>

--- a/lib/apipie/configuration.rb
+++ b/lib/apipie/configuration.rb
@@ -7,7 +7,8 @@ module Apipie
       :validate, :validate_value, :validate_presence, :validate_key, :authenticate, :doc_path,
       :show_all_examples, :process_params, :update_checksum, :checksum_path,
       :link_extension, :record, :languages, :translate, :locale, :default_locale,
-      :persist_show_in_doc
+      :persist_show_in_doc, :render_examples_with_template
+
 
     alias_method :validate?, :validate
     alias_method :required_by_default?, :required_by_default
@@ -165,6 +166,7 @@ module Apipie
       @translate = lambda { |str, locale| str }
       @persist_show_in_doc = false
       @routes_formatter = RoutesFormatter.new
+      @render_examples_with_template = false
     end
   end
 end


### PR DESCRIPTION
The examples were being formatted using string concatenation. I needed to have access at the template level.
So I added a new configuration property, render_examples_with_template,  which allows the user to render the examples in the method description from a partial, once set, the new example partial will be used, or that partial can be overridden like the others templates.

NOTE: I couldn't get the Example partial to look like the string concatenation, so thats why its configurable.