### PR TITLE
Load controllers if not eager loaded

### DIFF
--- a/app/controllers/apipie/apipies_controller.rb
+++ b/app/controllers/apipie/apipies_controller.rb
@@ -26,7 +26,8 @@ module Apipie
 
         @language = get_language
 
-        Apipie.reload_documentation if Apipie.configuration.reload_controllers?
+        Apipie.load_documentation if Apipie.configuration.reload_controllers? || (Rails.version.to_i >= 4.0 && !Rails.application.config.eager_load)
+
         I18n.locale = @language
         @doc = Apipie.to_json(params[:version], params[:resource], params[:method], @language)
 

--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -305,6 +305,13 @@ module Apipie
       locale = old_locale
     end
 
+    def load_documentation
+      if !@documentation_loaded || Apipie.configuration.reload_controllers?
+        Apipie.reload_documentation
+        @documentation_loaded = true
+      end
+    end
+
     def compute_checksum
       if Apipie.configuration.use_cache?
         file_base = File.join(Apipie.configuration.cache_dir, Apipie.configuration.doc_base_url)
@@ -313,7 +320,7 @@ module Apipie
           all_docs[File.basename(f, '.json')] = JSON.parse(File.read(f))
         end
       else
-        reload_documentation if available_versions == []
+        load_documentation if available_versions == []
         all_docs = Apipie.available_versions.inject({}) do |all, version|
           all.update(version => Apipie.to_json(version))
         end


### PR DESCRIPTION
### Description
If not eager loaded, we need to load controllers otherwise no documentation will be generated/displayed.
The logic of reloaded (when already loaded) is moved to the `reload_documentation` method.