### PR TITLE
Add PATCH to the POST, PUT list

### DIFF
--- a/lib/apipie/extractor/recorder.rb
+++ b/lib/apipie/extractor/recorder.rb
@@ -38,7 +38,7 @@ module Apipie
         @verb = request.request_method.to_sym
         @path = request.path
         @params = request.request_parameters
-        if [:POST, :PUT].include?(@verb)
+        if [:POST, :PUT, :PATCH].include?(@verb)
           @request_data = @params
         else
           @query = request.query_string


### PR DESCRIPTION
It would seem that a PATCH request should behave like a PUT and POST in how the parameters get mapped.  I think typically, since you could be patching a large enough data set, the parameters wouldn't go in the URL but would be submitted as part of the request body.  Rails form builders treat PATCH as a POST with a hidden parameter.