### PR TITLE
Avoid infinite recursion when there is a redirect

### DIFF
--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -53,11 +53,12 @@ module Apipie
 
     # the app might be nested when using contraints, namespaces etc.
     # this method does in depth search for the route controller
-    def route_app_controller(app, route)
+    def route_app_controller(app, route, visited_apps = [])
+      visited_apps << app
       if app.respond_to?(:controller)
         return app.controller(route.defaults)
-      elsif app.respond_to?(:app)
-        return route_app_controller(app.app, route)
+      elsif app.respond_to?(:app) && !visited_apps.include?(app.app)
+        return route_app_controller(app.app, route, visited_apps)
       end
     rescue ActionController::RoutingError
       # some errors in the routes will not stop us here: just ignoring

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -26,4 +26,5 @@ Dummy::Application.routes.draw do
     apipie
   end
   root :to => 'apipie/apipies#index'
+  match '(/)*path' => redirect('http://www.example.com'), :via => :all
 end


### PR DESCRIPTION
After upgrading to Rails 4.2.0, I began receiving a `SystemStackError` when Rails boots. After quite a bit of debugging, I traced it to the fact that I am using the `api!` method in my controllers to auto-detect the route for a given description. After more debugging, I traced it to the fact that I have several "catchall" redirects in my `routes.rb` file.

Apparently when the method `Apipie::Application#route_app_controller` attempts to recursively figure out the controller for a given app, the app generated from `redirect` satisfies none of the conditions and it will recurse until Ruby stops it.

I'm not sure of the exact fix, someone with more domain knowledge will have to say whether my patch is right or not. I was able to cause the problem under Rails 4.2 by adding the redirect route; I was able to stop the problem by adding another check to the condition.

Let me know if there is something more I can do to help with this PR.