### PR TITLE
Readme fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -616,10 +616,10 @@ Example:
      config.reload_controllers = Rails.env.development?
      config.api_controllers_matcher = File.join(Rails.root, "app", "controllers", "**","*.rb")
      config.api_routes = Rails.application.routes
-     config.app_info = "
+     config.app_info["1.0"] = "
        This is where you can inform user about your application and API
        in general.
-     ", '1.0'
+     "
      config.authenticate = Proc.new do
         authenticate_or_request_with_http_basic do |username, password|
           username == "test" && password == "supersecretpassword"

--- a/README.rst
+++ b/README.rst
@@ -649,7 +649,7 @@ option, like this:
 
 .. code:: ruby
 
-   class MyFormatter < Apipie::RailsFormatter
+   class MyFormatter < Apipie::RoutesFormatter
      def format_path(route)
        super.gsub(/\(.*?\)/, '').gsub('//','') # hide all implicit parameters
      end


### PR DESCRIPTION
* `app_info` updated to match https://github.com/Apipie/apipie-rails/blob/4627d69fd64766d4f973f3603599d9d0a53d8046/spec/dummy/config/initializers/apipie.rb#L51

```ruby
  # set default version info, to describe specific version use
  # config.app_info[version] = description
  # or put this in your base or application controller
  config.app_info = "Dummy app for testing"
```

* `RailsFormatter` has been renamed to `RoutesFormatter`