### PR TITLE
fix undefined method `content_tag`

### DIFF
--- a/app/helpers/apipie_helper.rb
+++ b/app/helpers/apipie_helper.rb
@@ -1,4 +1,5 @@
 module ApipieHelper
+  include ActionView::Helpers::TagHelper
 
   def heading(title, level=1)
     content_tag("h#{level}") do


### PR DESCRIPTION
Started getting the following exception after bumping from 0.3.3 to 0.3.4:

```
ActionView::Template::Error:
 undefined method `content_tag' for #<Apipie::ApipiesController:0x007ffdb1a5e608>
# /Users/emma/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/apipie-rails-0.3.4/app/helpers/apipie_helper.rb:4:in `heading'
# /Users/emma/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/actionpack-4.2.1/lib/abstract_controller/helpers.rb:67:in `heading'
# /Users/emma/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/apipie-rails-0.3.4/app/views/apipie/apipies/_method_detail.erb:27:in `___sers_emma__rbenv_versions_______lib_ruby_gems_______gems_apipie_rails_______app_views_apipie_apipies__method_detail_erb__4191062763070027136_70363792007840'
# /Users/emma/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/actionview-4.2.1/lib/action_view/template.rb:145:in `block in render'
```