### PR TITLE
Hide controller methods from documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -224,6 +224,9 @@ see
 meta
   Hash or array with custom metadata.
 
+show
+  Resource is hidden from documentation when set to false (true by default)
+
 Example:
 ~~~~~~~~
 
@@ -236,6 +239,7 @@ Example:
 
    # More complex example
    api :GET, "/users/:id", "Show user profile"
+   show false
    error :code => 401, :desc => "Unauthorized"
    error :code => 404, :desc => "Not Found", :meta => {:anything => "you can think of"}
    param :session, String, :desc => "user is logged in", :required => true

--- a/app/helpers/apipie_helper.rb
+++ b/app/helpers/apipie_helper.rb
@@ -1,4 +1,5 @@
 module ApipieHelper
+  include ActionView::Helpers::TagHelper
 
   def heading(title, level=1)
     content_tag("h#{level}") do

--- a/app/views/apipie/apipies/index.html.erb
+++ b/app/views/apipie/apipies/index.html.erb
@@ -28,6 +28,9 @@
     </thead>
     <tbody>
       <% api[:methods].each do |m| %>
+        <% if !m[:show] %>
+          <% next %>
+        <% end %>
         <% m[:apis].each do |a| %>
           <tr>
             <td>

--- a/app/views/apipie/apipies/plain.html.erb
+++ b/app/views/apipie/apipies/plain.html.erb
@@ -2,6 +2,9 @@
   <h4><a href='#<%= key %>'><%= resource[:name] %></a></h4>
   <ul>
     <% resource[:methods].each do |method| %>
+      <% if !method[:show] %>
+        <% next %>
+      <% end %>
       <li><a href='#<%= key %>-<%= method[:name] %>'><%= method[:name] %></a></li>
     <% end %>
   </ul>
@@ -26,6 +29,9 @@
   <div>
 
     <% resource[:methods].each do |method| %>
+      <% if !method[:show] %>
+        <% next %>
+      <% end %>
       <hr/>
 
       <h3 id="<%= "#{key}-#{method[:name]}" %>">

--- a/app/views/apipie/apipies/resource.html.erb
+++ b/app/views/apipie/apipies/resource.html.erb
@@ -37,6 +37,9 @@
 <div class='accordion' id='accordion'>
 
   <% @resource[:methods].each do |m| %>
+    <% if !m[:show] %>
+      <% next %>
+    <% end %>
     <hr>
     <div class='pull-right small'>
       <a href='<%= m[:doc_url] %><%= @doc[:link_extension] %>'> >>> </a>

--- a/app/views/apipie/apipies/static.html.erb
+++ b/app/views/apipie/apipies/static.html.erb
@@ -2,6 +2,9 @@
   <h4><a href='#<%= key %>'><%= resource[:name] %></a></h4>
   <ul>
     <% resource[:methods].each do |method| %>
+      <% if !method[:show] %>
+        <% next %>
+      <% end %>
       <li><a href='#<%= key %>-<%= method[:name] %>'><%= method[:name] %></a></li>
     <% end %>
   </ul>
@@ -34,6 +37,9 @@
   <div class='accordion' id='accordion'>
 
     <% resource[:methods].each do |method| %>
+      <% if !method[:show] %>
+        <% next %>
+      <% end %>
       <hr>
 
       <ul class='breadcrumb' id='<%= key %>-<%= method[:name] %>'>

--- a/lib/apipie/dsl_definition.rb
+++ b/lib/apipie/dsl_definition.rb
@@ -33,7 +33,8 @@ module Apipie
          :see               => [],
          :formats           => nil,
          :api_versions      => [],
-         :meta              => nil
+         :meta              => nil,
+         :show              => true
        }
       end
     end
@@ -109,6 +110,13 @@ module Apipie
       def example(example) #:doc:
         return unless Apipie.active_dsl?
         _apipie_dsl_data[:examples] << example.strip_heredoc
+      end
+
+      # Determine if the method should be included
+      # in the documentation
+      def show(show)
+        return unless Apipie.active_dsl?
+        _apipie_dsl_data[:show] = show
       end
 
       # Describe whole resource

--- a/lib/apipie/method_description.rb
+++ b/lib/apipie/method_description.rb
@@ -17,7 +17,7 @@ module Apipie
 
     end
 
-    attr_reader :full_description, :method, :resource, :apis, :examples, :see, :formats, :metadata, :headers
+    attr_reader :full_description, :method, :resource, :apis, :examples, :see, :formats, :metadata, :headers, :show
 
     def initialize(method, resource, dsl_data)
       @method = method.to_s
@@ -49,6 +49,12 @@ module Apipie
       end
       @params_ordered = ParamDescription.unify(@params_ordered)
       @headers = dsl_data[:headers]
+
+      @show = if dsl_data.has_key? :show
+        dsl_data[:show]
+      else
+        true
+      end
     end
 
     def id
@@ -144,7 +150,8 @@ module Apipie
         :examples => @examples,
         :metadata => @metadata,
         :see => see.map(&:to_json),
-        :headers => headers
+        :headers => headers,
+        :show => @show
       }
     end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -402,6 +402,7 @@ describe UsersController do
       context "the key is valid" do
         it "should contain reference to another method" do
           api = Apipie[UsersController, :see_another]
+          api.show.should == false
           see = api.see.first
           see.see_url.should == Apipie[UsersController, :create].doc_url
           see.link.should == 'development#users#create'
@@ -571,6 +572,7 @@ describe UsersController do
                      :expected_type=>"numeric"},
        ],
         :name => 'two_urls',
+        :show => true,
         :apis => [
           {
             :http_method => 'GET',

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -169,6 +169,7 @@ class UsersController < ApplicationController
     More builder documentation can be found at http://builder.rubyforge.org.
   eos
   api :GET, "/users/:id", "Show user profile"
+  show false
   formats ['json', 'jsonp']
   error 401, "Unauthorized"
   error :code => 404, :description => "Not Found"
@@ -256,9 +257,10 @@ class UsersController < ApplicationController
   end
 
   api :GET, '/users/see_another', 'Boring method'
+  show false
   see 'development#users#create'
   see 'development#users#index', "very interesting method reference"
-  desc 'This method is boring, look at users#create'
+  desc 'This method is boring, look at users#create.  It is hidden from documentation.'
   def see_another
     render :text => 'This is very similar to create action'
   end


### PR DESCRIPTION
Reasons for feature and a description of the functionality described in issue https://github.com/Apipie/apipie-rails/issues/355

Example:

```
api :GET, '/users/see_another', 'Boring hidden method that we do not want clients to know about yet'
show false
see 'development#users#create'
see 'development#users#index', "very interesting method reference"
desc 'This method is boring, look at users#create.  It is hidden from documentation.'
def see_another
  render :text => 'This is very similar to create action'
end
```