### PR TITLE
Display engine path in documentation when using api!

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "https://rubygems.org"
 
 gemspec
 
+gem 'test_engine', path: 'spec/dummy/components/test_engine', group: :test
+
 # load local gemfile
 local_gemfile = File.join(File.dirname(__FILE__), 'Gemfile.local')
 self.instance_eval(Bundler.read_file(local_gemfile)) if File.exist?(local_gemfile)

--- a/Gemfile.rails32
+++ b/Gemfile.rails32
@@ -4,3 +4,4 @@ gemspec
 
 gem 'rails', '~> 3.2.0'
 gem 'test-unit', '~> 3.0'
+gem 'test_engine', path: 'spec/dummy/components/test_engine', group: :test

--- a/Gemfile.rails40
+++ b/Gemfile.rails40
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rails', '~> 4.0.0'
+gem 'test_engine', path: 'spec/dummy/components/test_engine', group: :test

--- a/Gemfile.rails41
+++ b/Gemfile.rails41
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rails', '~> 4.1.0'
+gem 'test_engine', path: 'spec/dummy/components/test_engine', group: :test

--- a/Gemfile.rails42
+++ b/Gemfile.rails42
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rails', '~> 4.2.5.1'
+gem 'test_engine', path: 'spec/dummy/components/test_engine', group: :test

--- a/lib/apipie-rails.rb
+++ b/lib/apipie-rails.rb
@@ -1,6 +1,8 @@
 require 'i18n'
 require 'active_support/hash_with_indifferent_access'
 
+require 'apipie/core_ext/route.rb'
+
 require "apipie/routing"
 require "apipie/markup"
 require "apipie/apipie_module"

--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -40,9 +40,11 @@ module Apipie
       flatten_routes = []
 
       route_set.routes.each do |route|
-        if route.app.respond_to?(:routes) && route.app.routes.is_a?(ActionDispatch::Routing::RouteSet)
+        # This is a hack to workaround a bug in apipie with Rails 4.2.5.1 or newer. See https://github.com/Apipie/apipie-rails/issues/415
+        route_app = Rails::VERSION::STRING.to_f >= 4.2 ? route.app.app : route.app
+        if route_app.respond_to?(:routes) && route_app.routes.is_a?(ActionDispatch::Routing::RouteSet)
           # recursively go though the mounted engines
-          flatten_routes.concat(rails_routes(route.app.routes, File.join(base_url, route.path.spec.to_s)))
+          flatten_routes.concat(rails_routes(route_app.routes, File.join(base_url, route.path.spec.to_s)))
         else
           route.base_url = base_url
           flatten_routes << route

--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -29,7 +29,7 @@ module Apipie
       @controller_to_resource_id[controller] = resource_id
     end
 
-    def rails_routes(route_set = nil)
+    def rails_routes(route_set = nil, base_url = "")
       if route_set.nil? && @rails_routes
         return @rails_routes
       end
@@ -41,9 +41,10 @@ module Apipie
 
       route_set.routes.each do |route|
         if route.app.respond_to?(:routes) && route.app.routes.is_a?(ActionDispatch::Routing::RouteSet)
-          # recursively go though the moutned engines
-          flatten_routes.concat(rails_routes(route.app.routes))
+          # recursively go though the mounted engines
+          flatten_routes.concat(rails_routes(route.app.routes, File.join(base_url, route.path.spec.to_s)))
         else
+          route.base_url = base_url
           flatten_routes << route
         end
       end

--- a/lib/apipie/core_ext/route.rb
+++ b/lib/apipie/core_ext/route.rb
@@ -1,3 +1,10 @@
-ActionDispatch::Journey::Route.class_eval do
+begin
+  # Rails 4
+  ActionDispatch::Journey
+rescue NameError
+  # Rails 3
+  require 'journey'
+  Journey
+end::Route.class_eval do
   attr_accessor :base_url
 end

--- a/lib/apipie/core_ext/route.rb
+++ b/lib/apipie/core_ext/route.rb
@@ -1,0 +1,3 @@
+ActionDispatch::Journey::Route.class_eval do
+  attr_accessor :base_url
+end

--- a/lib/apipie/routes_formatter.rb
+++ b/lib/apipie/routes_formatter.rb
@@ -16,7 +16,7 @@ module Apipie
     end
 
     def format_path(rails_route)
-      rails_route.path.spec.to_s.gsub('(.:format)', '')
+      File.join(rails_route.base_url, rails_route.path.spec.to_s.gsub('(.:format)', ''))
     end
 
     def format_verb(rails_route)

--- a/spec/controllers/memes_controller_spec.rb
+++ b/spec/controllers/memes_controller_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe TestEngine::MemesController do
+
+  describe "#index" do
+    it "should have the full mounted path of engine" do
+      Apipie.routes_for_action(TestEngine::MemesController, :index, {}).first[:path].should eq("/test/memes")
+    end
+  end
+end

--- a/spec/dummy/components/test_engine/Gemfile
+++ b/spec/dummy/components/test_engine/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+# Declare your gem's dependencies in test_engine.gemspec.
+# Bundler will treat runtime dependencies like base dependencies, and
+# development dependencies will be added by default to the :development group.
+gemspec

--- a/spec/dummy/components/test_engine/app/controllers/test_engine/application_controller.rb
+++ b/spec/dummy/components/test_engine/app/controllers/test_engine/application_controller.rb
@@ -1,0 +1,4 @@
+module TestEngine
+  class ApplicationController < ActionController::Base
+  end
+end

--- a/spec/dummy/components/test_engine/app/controllers/test_engine/memes_controller.rb
+++ b/spec/dummy/components/test_engine/app/controllers/test_engine/memes_controller.rb
@@ -1,0 +1,37 @@
+module TestEngine
+  class MemesController < TestEngine::ApplicationController
+    api! 'Returns a list of all good memes on Twitter'
+    param :api_token, String, required: true, desc: 'Your Twitter API token'
+    def index
+      render json: []
+    end
+
+    api! 'Shows info about a particular meme on Twitter'
+    param :id, :number, required: true, desc: 'ID of the meme'
+    def show
+      render json: {id: params[:id]}
+    end
+
+    api! 'Create a new meme on Twitter'
+    param :api_token, String, required: true, desc: 'Your Twitter API token'
+    param :name, String, required: true, desc: 'Name of your meme'
+    param :src_url, String, required: true, desc: 'URL for your meme'
+    def create
+      render json: {name: params[:name], src_url: params[:src_url]}, status: :created
+    end
+
+    api! 'Update a meme on Twitter'
+    param :api_token, String, required: true, desc: 'Your Twitter API token'
+    param :name, String, required: false, desc: 'Name of your meme'
+    param :src_url, String, required: false, desc: 'URL for your meme'
+    def update
+      render json: {name: params[:name], src_url: params[:src_url]}
+    end
+
+    api! 'Delete a meme on Twitter'
+    param :id, :number, required: true, desc: 'ID of the meme'
+    def destroy
+      head :ok
+    end
+  end
+end

--- a/spec/dummy/components/test_engine/config/routes.rb
+++ b/spec/dummy/components/test_engine/config/routes.rb
@@ -1,0 +1,3 @@
+TestEngine::Engine.routes.draw do
+  resources :memes, only: [:index, :show, :create, :update, :destroy]
+end

--- a/spec/dummy/components/test_engine/lib/test_engine.rb
+++ b/spec/dummy/components/test_engine/lib/test_engine.rb
@@ -1,0 +1,7 @@
+require 'apipie-rails'
+
+module TestEngine
+  class Engine < ::Rails::Engine
+    isolate_namespace TestEngine
+  end
+end

--- a/spec/dummy/components/test_engine/test_engine.gemspec
+++ b/spec/dummy/components/test_engine/test_engine.gemspec
@@ -1,0 +1,11 @@
+$:.push File.expand_path('../lib', __FILE__)
+
+# Describe your gem and declare its dependencies:
+Gem::Specification.new do |s|
+  s.name        = 'test_engine'
+  s.version     = '0.0.1'
+  s.summary     = 'Test Engine'
+  s.authors     = 'Test Author'
+
+  s.files = Dir['{app,config,db,lib}/**/*']
+end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -8,6 +8,7 @@ require "action_mailer/railtie"
 
 Bundler.require
 require "apipie-rails"
+require "test_engine"
 
 module Dummy
   class Application < Rails::Application

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,5 +1,7 @@
 Dummy::Application.routes.draw do
 
+  mount TestEngine::Engine => '/test'
+
   scope ENV['RAILS_RELATIVE_URL_ROOT'] || '/' do
 
     scope '/api' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require File.expand_path("../dummy/config/environment", __FILE__)
 require 'rspec/rails'
 
 require 'apipie-rails'
+require 'test_engine'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
If my_engine is mounted at '/engine', ApiPie documentation will now
include "/engine" as part of the path when using api!
