### PR TITLE
Allow , and . in numbers, so decimals are allowed

### DIFF
--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -391,7 +391,7 @@ module Apipie
       end
 
       def self.validate(value)
-        value.to_s =~ /\A(0|[1-9]\d*)\Z$/
+        value.to_s =~ /\A([0-9]+[,.]*\d*)\Z$/
       end
     end
 


### PR DESCRIPTION
Can't manage to use validation on decimal values supplied via a json api without this. The ',' allows number with locale other than english to be used, too