### PR TITLE
rdoc is needed when in production as well

### DIFF
--- a/apipie-rails.gemspec
+++ b/apipie-rails.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "maruku"
   s.add_development_dependency "RedCloth"
   s.add_development_dependency "rake"
-  s.add_development_dependency "rdoc"
+  s.add_dependency "rdoc"
 end


### PR DESCRIPTION
When deploying this to production I received errors about rdoc. This commit fixes it.