### PR TITLE
Add custom message support for missing parameters 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -291,6 +291,10 @@ meta
 show
   Parameter is hidden from documentation when set to false (true by default)
 
+missing-message
+  Specify the message to be returned if the parameter is missing as a string or Proc.
+  Defaults to ``Missing parameter #{name}`` if not specified.
+
 Example:
 ~~~~~~~~
 
@@ -301,6 +305,7 @@ Example:
      param :password, String, :desc => "Password for login", :required => true
      param :membership, ["standard","premium"], :desc => "User membership"
      param :admin_override, String, :desc => "Not shown in documentation", :show => false
+     param :ip_address, String, :desc => "IP address", :required => true, :missing_message => lambda { I18n.t("ip_address.required") }
    end
    def create
      #...

--- a/lib/apipie/dsl_definition.rb
+++ b/lib/apipie/dsl_definition.rb
@@ -223,7 +223,7 @@ module Apipie
               if Apipie.configuration.validate_presence?
                 method_params.each do |_, param|
                   # check if required parameters are present
-                  raise ParamMissing.new(param.name) if param.required && !params.has_key?(param.name)
+                  raise ParamMissing.new(param) if param.required && !params.has_key?(param.name)
                 end
               end
 

--- a/lib/apipie/errors.rb
+++ b/lib/apipie/errors.rb
@@ -17,7 +17,15 @@ module Apipie
 
   class ParamMissing < DefinedParamError
     def to_s
-      "Missing parameter #{@param}"
+      unless @param.options[:missing_message].nil?
+        if @param.options[:missing_message].kind_of?(Proc)
+          @param.options[:missing_message].call
+        else
+          @param.options[:missing_message].to_s
+        end
+      else
+        "Missing parameter #{@param.name}"
+      end
     end
   end
 

--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -305,7 +305,7 @@ module Apipie
         if @hash_params
           @hash_params.each do |k, p|
             if Apipie.configuration.validate_presence?
-              raise ParamMissing.new(k) if p.required && !value.has_key?(k)
+              raise ParamMissing.new(p) if p.required && !value.has_key?(k)
             end
             if Apipie.configuration.validate_value?
               p.validate(value[k]) if value.has_key?(k)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -97,7 +97,7 @@ describe UsersController do
           end
 
           it "should fail if required parameter is missing" do
-            expect { get :show, :id => 5 }.to raise_error(Apipie::ParamMissing, /\bsession\b/)
+            expect { get :show, :id => 5 }.to raise_error(Apipie::ParamMissing, /session_parameter_is_required/)
           end
 
           it "should pass if required parameter has wrong type" do
@@ -144,7 +144,7 @@ describe UsersController do
           end
 
           it "should fail if required parameter is missing" do
-            expect { get :show, :id => 5 }.to raise_error(Apipie::ParamMissing, /\bsession\b/)
+            expect { get :show, :id => 5 }.to raise_error(Apipie::ParamMissing, /session_parameter_is_required/)
           end
 
           it "should work with custom Type validator" do

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -174,7 +174,7 @@ class UsersController < ApplicationController
   error 401, "Unauthorized"
   error :code => 404, :description => "Not Found"
   param :id, Integer, :desc => "user id", :required => true
-  param :session, String, :desc => "user is logged in", :required => true
+  param :session, String, :desc => "user is logged in", :required => true, :missing_message => lambda { "session_parameter_is_required" }
   param :regexp_param, /^[0-9]* years/, :desc => "regexp param"
   param :regexp2, /\b[A-Z0-9._%+-=]+@[A-Z0-9.-]+.[A-Z]{2,}\b/i, :desc => "email regexp"
   param :array_param, ["100", "one", "two", "1", "2"], :desc => "array validator"


### PR DESCRIPTION
`ParamMissing` can take the entire `ParamDescription` object instead of just the name, allowing it to interrogate the object to produce a custom missing message instead of the boilerplate `"Missing parameter #{@param.name}"`. Support is for a basic string or function. 

A primary use case for this is when an API is returning an error message that a client can then surface directly to a user without having to maintain a mapping of parameter names to human readable names IE 
`Missing parameter user_id` to `A user must be supplied to complete this action.`. An additional benefit in allowing a `Proc` is that we can evaluate runtime conditions to create the message, thereby allowing internationalization and providing greater usefulness in the error message.

This would also address the feature request in issue #360