### PR TITLE
Add viewport meta tag.

### DIFF
--- a/app/views/layouts/apipie/apipie.html.erb
+++ b/app/views/layouts/apipie/apipie.html.erb
@@ -3,6 +3,7 @@
 <head>
   <title><%= t('apipie.api_documentation') %></title>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <%= Apipie.include_stylesheets %>
   <link type='text/css' rel='stylesheet' href='<%= Apipie.full_url("stylesheets/application.css")%>'/>
   <!-- IE6-8 support of HTML5 elements -->


### PR DESCRIPTION
Thanks for an awesome gem :+1: 

I just added a viewport meta tag to make the documentation easier to read on mobile devices.

## Before
![before](https://cloud.githubusercontent.com/assets/922411/11769143/9b2d1662-a1e0-11e5-95d5-76ca214cd8b2.png)


## After
![after](https://cloud.githubusercontent.com/assets/922411/11769144/9e0f30d6-a1e0-11e5-8410-6427a3f37bd4.png)


Tested on Android chrome (and chrome/safari/firefox on desktop).

Thanks again :)