### PR TITLE
Fix typo in Action Aware Params section of readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -392,7 +392,7 @@ Example
    def_param_group :user do
      param :user, Hash, :action_aware => true do
        param :name, String, :required => true
-       param :description, :String
+       param :description, String
      end
    end
 


### PR DESCRIPTION
I believe this is supposed to be the `String` object instead of `:String` symbol.

Attaching a screenshot with the error:
![1__tmux_and_runtimeerror_at__apipie_1_0_events_show_html](https://cloud.githubusercontent.com/assets/1318878/12528336/63c5baf2-c158-11e5-96cc-660917d7f07e.jpg)

