### PR TITLE
Replace #before_filter with #before_action

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -528,7 +528,7 @@ default_version
 validate
   Parameters validation is turned off when set to false. When set to
   ``:explicitly``, you must invoke parameter validation yourself by calling
-  controller method ``apipie_validations`` (typically in a before_filter).
+  controller method ``apipie_validations`` (typically in a before_action).
   When set to ``:implicitly`` (or just true), your controller's action
   methods are wrapped with generated methods which call ``apipie_validations``,
   and then call the action method. (``:implicitly`` by default)
@@ -726,17 +726,17 @@ is raised and can be rescued and processed. It contains a description
 of the parameter value expectations. Validations can be turned off
 in the configuration file.
 
-Parameter validation normally happens after before_filters, just before
+Parameter validation normally happens after before_actions, just before
 your controller method is invoked. If you prefer to control when parameter
 validation occurs, set the configuration parameter ``validate`` to ``:explicitly``.
 You must then call the ``apipie_validations`` method yourself, e.g.:
 
 .. code:: ruby
 
-   before_filter: :apipie_validations
+   before_action: :apipie_validations
 
-This is useful if you have before_filters which use parameter values: just add them
-after the ``apipie_validations`` before_filter.
+This is useful if you have before_actions which use parameter values: just add them
+after the ``apipie_validations`` before_action.
 
 TypeValidator
 -------------

--- a/app/controllers/apipie/apipies_controller.rb
+++ b/app/controllers/apipie/apipies_controller.rb
@@ -5,8 +5,8 @@ module Apipie
 
     layout Apipie.configuration.layout
 
-    around_filter :set_script_name
-    before_filter :authenticate
+    around_action :set_script_name
+    before_action :authenticate
 
     def authenticate
       if Apipie.configuration.authenticate

--- a/lib/apipie/extractor.rb
+++ b/lib/apipie/extractor.rb
@@ -9,7 +9,7 @@ require 'apipie/extractor/collector'
 class Apipie::Railtie
   initializer 'apipie.extractor' do |app|
     ActiveSupport.on_load :action_controller do
-      before_filter do |controller|
+      before_action do |controller|
         if Apipie.configuration.record
           Apipie::Extractor.call_recorder.analyse_controller(controller)
         end

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  before_filter :run_validations
+  before_action :run_validations
   
   resource_description do
     param :oauth, String, :desc => "Authorization", :required => false


### PR DESCRIPTION
Fixes

```
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead. (called from block (2 levels) in <class:Railtie> at /Users/someusername/.gem/ruby/2.3.0/gems/apipie-rails-0.3.5/lib/apipie/extractor.rb:12)
```
