### PR TITLE
Fix layout path (Rails 4.2.5.1 compatibility)

### DIFF
--- a/Gemfile.rails42
+++ b/Gemfile.rails42
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'rails', '~> 4.2.5'
+gem 'rails', '~> 4.2.5.1'

--- a/lib/tasks/apipie.rake
+++ b/lib/tasks/apipie.rake
@@ -105,7 +105,8 @@ namespace :apipie do
                 else
                   File.expand_path("../../../app/views/apipie/apipies", __FILE__)
                 end
-    @apipie_renderer = ActionView::Base.new(base_path)
+    layouts_path = File.expand_path("../../../app/views/layouts", __FILE__)
+    @apipie_renderer = ActionView::Base.new([base_path, layouts_path])
     @apipie_renderer.singleton_class.send(:include, ApipieHelper)
     return @apipie_renderer
   end
@@ -118,7 +119,7 @@ namespace :apipie do
       end
       f.write av.render(
         :template => "#{template}",
-        :layout => (layout && "../../layouts/apipie/#{layout}"))
+        :layout => (layout && "apipie/#{layout}"))
     end
   end
 


### PR DESCRIPTION
Fixes #421 (Missing template ../../layouts/apipie/apipie ... error). Credits: @FooBarWidget's [comment](https://github.com/Apipie/apipie-rails/issues/421#issuecomment-177998315).