### PR TITLE
Render enum param values as CODE

### DIFF
--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -149,7 +149,8 @@ module Apipie
       end
 
       def description
-        "Must be one of: #{@array.join(', ')}."
+        string = @array.map { |value| "<code>#{value}</code>" }.join(', ')
+        "Must be one of: #{string}."
       end
     end
 


### PR DESCRIPTION
If an resource enum parameter has values that end in whitespace or dot
it can be hard to tell with certainty from the generated
documentation. This is because values aren't quoted or otherwise
enclosed. This patch encloses them in CODE elements, which stand out
with clarity from surrounding text.

Before:
<img width="483" alt="screen shot 2016-02-02 at 21 23 18" src="https://cloud.githubusercontent.com/assets/4313/12763452/d58e0c76-c9f4-11e5-9409-58627deed7d3.png">

After:
<img width="537" alt="screen shot 2016-02-02 at 21 20 26" src="https://cloud.githubusercontent.com/assets/4313/12763460/e13ac73a-c9f4-11e5-9b82-d668b0e1d03c.png">

