### PR TITLE
Add process_value to BooleanValidator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -712,6 +712,8 @@ For an enumeration type:
     value ? value.split(',') : []
    end
 
+The processed value will be available in ``@api_params``.
+
 ============
  Validators
 ============

--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -398,13 +398,17 @@ module Apipie
     class BooleanValidator < BaseValidator
 
       def validate(value)
-        %w[true false 1 0].include?(value.to_s)
+        %w[true false 1 0].include?(value.to_s.downcase)
       end
 
       def self.build(param_description, argument, options, block)
         if argument == :bool || argument == :boolean
           self.new(param_description)
         end
+      end
+      
+      def process_value(value)
+        %w[true 1].include?(value.to_s.downcase)
       end
 
       def expected_type


### PR DESCRIPTION
If using apipie's param processing, I want to get back boolean values for a :boolean param, not the original string. Also document the need for `@api_params` in the readme.