### PR TITLE
Improved support for multipart/form-data example recording

### DIFF
--- a/lib/apipie/extractor/collector.rb
+++ b/lib/apipie/extractor/collector.rb
@@ -24,10 +24,10 @@ module Apipie
       end
 
       def handle_record(record)
-        add_to_records(record)
         if ignore_call?(record)
           Extractor.logger.info("REST_API: skipping #{record_to_s(record)}")
         else
+          add_to_records(record)
           refine_description(record)
         end
       end
@@ -110,4 +110,3 @@ module Apipie
     end
   end
 end
-

--- a/lib/apipie/extractor/recorder.rb
+++ b/lib/apipie/extractor/recorder.rb
@@ -13,6 +13,7 @@ module Apipie
         @query = env["QUERY_STRING"] unless env["QUERY_STRING"].blank?
         @params = Rack::Utils.parse_nested_query(@query)
         @params.merge!(env["action_dispatch.request.request_parameters"] || {})
+        
         if data = parse_data(env["rack.input"].read)
           @request_data = data
           env["rack.input"].rewind
@@ -39,7 +40,11 @@ module Apipie
         @path = request.path
         @params = request.request_parameters
         if [:POST, :PUT, :PATCH].include?(@verb)
-          @request_data = @params
+          if request.content_type == "multipart/form-data"
+            @request_data = reformat_multipart_data(@params)
+          else
+            @request_data = @params
+          end
         else
           @query = request.query_string
         end
@@ -61,6 +66,12 @@ module Apipie
         form.each do |key, attrs|
           if attrs.is_a?(String)
             lines << boundary << content_disposition(key) << "Content-Length: #{attrs.size}" << '' << attrs
+          elsif attrs.is_a?(Rack::Test::UploadedFile) || attrs.is_a?(ActionDispatch::Http::UploadedFile)
+            reformat_uploadedfile(boundary, attrs, key, lines)
+          elsif attrs.is_a?(Array)
+            reformat_array(boundary, attrs, key, lines)
+          elsif attrs.is_a?(TrueClass) || attrs.is_a?(FalseClass)
+            reformat_boolean(boundary, attrs, key, lines)
           else
             reformat_hash(boundary, attrs, lines)
           end
@@ -79,6 +90,24 @@ module Apipie
           # Look for subelements that contain a part.
           attrs.each { |k,v| v.is_a?(Hash) and reformat_hash(boundary, v, lines) }
         end
+      end
+      
+      def reformat_boolean(boundary, attrs, key, lines)
+        lines << boundary << content_disposition(key)
+        lines << '' << attrs.to_s
+      end
+      
+      def reformat_array(boundary, attrs, key, lines)
+        attrs.each do |item|
+          lines << boundary << content_disposition("#{key}[]")
+          lines << '' << item
+        end
+      end
+      
+      def reformat_uploadedfile(boundary, file, key, lines)
+        lines << boundary << %{#{content_disposition(key)}; filename="#{file.original_filename}"}
+        lines << "Content-Length: #{file.size}" << "Content-Type: #{file.content_type}" << "Content-Transfer-Encoding: binary"
+        lines << '' << %{... contents of "#{key}" ...}
       end
 
       def content_disposition(name)


### PR DESCRIPTION
- Works with functional tests when the Content-Type is added to the request.env before calling the request.
  - i.e. `@request.env["CONTENT_TYPE"] = "multipart/form-data"`
- Is now able to format UploadedFiles from functional tests properly.
- Fixed formatting of Array and Boolean parameters.
  - These errored before from being treated as hashes.
