### PR TITLE
Added interpolation for :version symbol

### DIFF
--- a/app/controllers/apipie/apipies_controller.rb
+++ b/app/controllers/apipie/apipies_controller.rb
@@ -55,6 +55,11 @@ module Apipie
           if @doc[:resources].blank?
             render "getting_started" and return
           end
+          @doc[:resources].each do |k, r|
+            (params[:resource].present? ? k : r)[:methods].each do |m|
+              m[:apis].each { |a| a[:api_url].sub!(/\:version/, params[:version]) }
+            end
+          end
           @resource = @doc[:resources].first if params[:resource].present?
           @method = @resource[:methods].first if params[:method].present?
           @languages = Apipie.configuration.languages


### PR DESCRIPTION
Example:

```
class Api::CompaniesController < ApiController

  api :GET, '/:version/companies', 'List of companies'
  api_versions "1", "2"
  ...

end
```
The result in apidoc will look like:

For version is 1:

`GET /api/1/companies`

For version is 2:

`GET /api/2/companies`