### PR TITLE
Add ArrayOf validator

### DIFF
--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -247,6 +247,50 @@ module Apipie
       end
     end
 
+    class ArrayOfValidator < Apipie::Validator::BaseValidator
+      class << self
+        def for_class
+          :array_of_validator
+        end
+
+        def build(param_description, argument, options, block)
+          if argument == for_class
+            new(param_description, options, block)
+          end
+        end
+      end
+
+      def initialize(param_description, options, block)
+        super(param_description)
+        @items_type = options[:of]
+        @options = options
+        @block = block
+      end
+
+      def validate(values)
+        values ||= []
+        return false unless values.respond_to?(:each) && !values.is_a?(String)
+        values.all? { |v| validate_item(v) }
+      end
+
+      def validate_item(value)
+        Apipie::Validator::BaseValidator.find(
+          param_description,
+          items_type,
+          options,
+          block,
+        ).validate(value)
+      end
+
+      def description
+        "Must be array of #{items_type}s."
+      end
+
+      private
+
+      attr_reader :items_type, :param_description, :options, :block
+    end
+
     class ProcValidator < BaseValidator
 
       def initialize(param_description, argument)

--- a/spec/lib/validators/array_of_validator_spec.rb
+++ b/spec/lib/validators/array_of_validator_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+
+module Apipie::Validator
+  describe ArrayOfValidator do
+    let(:options) { { of: Integer } }
+    let(:validator) do
+      described_class.new(
+        "param_description",
+        options,
+        proc {},
+      )
+    end
+
+    class << self
+      def it_returns_true
+        it "returns true" do
+          expect(validator.validate(value)).to be_truthy
+        end
+      end
+
+      def it_returns_false
+        it "returns false" do
+          expect(validator.validate(value)).to be_falsey
+        end
+      end
+    end
+
+    describe "#validate" do
+      context "nil" do
+        let(:value) { nil }
+
+        it_returns_true
+      end
+
+      context "empty array" do
+        let(:value) { [] }
+
+        it_returns_true
+      end
+
+      context "contains desired type" do
+        let(:value) { [1] }
+
+        it_returns_true
+      end
+
+      context "contains wrong type" do
+        let(:value) { [1, "a"] }
+
+        it_returns_false
+      end
+    end
+  end
+end


### PR DESCRIPTION
### The intended usage

```ruby
param :ids, ArrayOfValidator.for_class, of: Integer
```

### Explanation

Instead of simply checking the value is an Integer, it will try to find
a validator for that type.

### Motivation

Rails of pass Integers as string. For example, instead of `ids: [1, 2]`
it could be `ids: ["1", "2"]`. In this case, we would still think this
is valid input.

But if we do

```ruby
param :ids, Array, of: Integer
```

an error will be raised for `"1"` is not an number

### Miscs

I realize the existence of #189 but that PR doesn't solve this particular problem. Nor did `ArrayClassValidator`

If you fee this PR is worthy I will add README section

Thanks!