### PR TITLE
Allow layouts to be overridable. Fixes a regression introduced in #425.

### DIFF
--- a/lib/tasks/apipie.rake
+++ b/lib/tasks/apipie.rake
@@ -105,7 +105,11 @@ namespace :apipie do
                 else
                   File.expand_path("../../../app/views/apipie/apipies", __FILE__)
                 end
-    layouts_path = File.expand_path("../../../app/views/layouts", __FILE__)
+    layouts_path = if File.directory?("#{Rails.root}/app/views/layouts/apipie")
+                     "#{Rails.root}/app/views/layouts"
+                   else
+                     File.expand_path("../../../app/views/layouts", __FILE__)
+                   end
     @apipie_renderer = ActionView::Base.new([base_path, layouts_path])
     @apipie_renderer.singleton_class.send(:include, ApipieHelper)
     return @apipie_renderer


### PR DESCRIPTION
After upgrading to version 0.3.6 our own custom layout wasn't used. This fix makes `base_path` and  `layouts_path` behave the same way.

The regression was introduced in #425.