### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Run your application and see the result at
 use ``http://localhost:3000/apipie.json``.
 
 For a more comprehensive getting started guide, see
-`this demo <https://github.com/iNecas/apipie-demo>`_, which includes
+`this demo <https://github.com/Apipie/apipie-demo>`_, which includes
 features such as generating documentation from tests, recording examples etc.
 
 Screenshots
@@ -78,7 +78,7 @@ See `Contributors page  <https://github.com/Apipie/apipie-rails/graphs/contribut
 License
 -------
 
-Apipie-rails is released under the `MIT License <http://opensource.org/licenses/MIT>`_
+Apipie-rails is released under the `MIT License <https://opensource.org/licenses/MIT>`_
 
 ===============
  Documentation
@@ -1299,7 +1299,7 @@ And if you write one on your own, don't hesitate to share it with us!
  Disqus Integration
 ====================
 
-You can setup `Disqus <http://www.disqus.com>`_ discussion within
+You can setup `Disqus <https://disqus.com/>`_ discussion within
 your documentation. Just set the credentials in the Apipie
 configuration:
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein
### GitHub Corrected URLs

| Was | Now |
| --- | --- |
| https://github.com/iNecas/apipie-demo | https://github.com/Apipie/apipie-demo |
### HTTPS Corrected URLs

| Was | Now |
| --- | --- |
| http://opensource.org/licenses/MIT | https://opensource.org/licenses/MIT |
### Other Corrected URLs

| Was | Now |
| --- | --- |
| http://www.disqus.com | https://disqus.com/ |
