### PR TITLE
Handle blank data when parsing a example's response

### DIFF
--- a/lib/apipie/extractor/recorder.rb
+++ b/lib/apipie/extractor/recorder.rb
@@ -48,9 +48,9 @@ module Apipie
       end
 
       def parse_data(data)
-        return nil if data.to_s =~ /^\s*$/
+        return nil if data.strip.blank?
         JSON.parse(data)
-      rescue StandardError => e
+      rescue StandardError
         data
       end
 


### PR DESCRIPTION
Currently, if an example's response body contains any blank line, it
returns nil.  This changes the approach to check for blank or all
whitespace to just data.strip.blank?