### PR TITLE
Pin mime-types to < 3.0 for Ruby 1.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,13 @@ source "https://rubygems.org"
 
 gemspec
 
+# mime-types 3.0 dropped support for Ruby 1.9
+group :development do
+  if RUBY_VERSION.start_with? '1.9'
+    gem 'mime-types', '< 3'
+  end
+end
+
 # load local gemfile
 local_gemfile = File.join(File.dirname(__FILE__), 'Gemfile.local')
 self.instance_eval(Bundler.read_file(local_gemfile)) if File.exist?(local_gemfile)

--- a/Gemfile.rails32
+++ b/Gemfile.rails32
@@ -2,5 +2,12 @@ source "https://rubygems.org"
 
 gemspec
 
+# mime-types 3.0 dropped support for Ruby 1.9
+group :development do
+  if RUBY_VERSION.start_with? '1.9'
+    gem 'mime-types', '< 3'
+  end
+end
+
 gem 'rails', '~> 3.2.0'
 gem 'test-unit', '~> 3.0'

--- a/Gemfile.rails40
+++ b/Gemfile.rails40
@@ -2,4 +2,11 @@ source "https://rubygems.org"
 
 gemspec
 
+# mime-types 3.0 dropped support for Ruby 1.9
+group :development do
+  if RUBY_VERSION.start_with? '1.9'
+    gem 'mime-types', '< 3'
+  end
+end
+
 gem 'rails', '~> 4.0.0'

--- a/Gemfile.rails41
+++ b/Gemfile.rails41
@@ -2,4 +2,11 @@ source "https://rubygems.org"
 
 gemspec
 
+# mime-types 3.0 dropped support for Ruby 1.9
+group :development do
+  if RUBY_VERSION.start_with? '1.9'
+    gem 'mime-types', '< 3'
+  end
+end
+
 gem 'rails', '~> 4.1.0'

--- a/Gemfile.rails42
+++ b/Gemfile.rails42
@@ -2,4 +2,11 @@ source "https://rubygems.org"
 
 gemspec
 
+# mime-types 3.0 dropped support for Ruby 1.9
+group :development do
+  if RUBY_VERSION.start_with? '1.9'
+    gem 'mime-types', '< 3'
+  end
+end
+
 gem 'rails', '~> 4.2.5.1'


### PR DESCRIPTION
So, recent test failures are because mime-types has dropped support for Ruby 1.9 in 3.0.   You probably don't need this and can wait for the problem to be fixed in mail itself. I mostly just wanted a travis run to see if it was green after this.

I submitted a PR here https://github.com/mikel/mail/pull/991.
