### PR TITLE
Remove json gem dependency

### DIFF
--- a/apipie-rails.gemspec
+++ b/apipie-rails.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "rails", ">= 4.0"
-  s.add_dependency 'json'
   s.add_development_dependency "rspec-rails", "~> 3.0"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "minitest"

--- a/lib/apipie-rails.rb
+++ b/lib/apipie-rails.rb
@@ -1,4 +1,5 @@
 require 'i18n'
+require 'json'
 require 'active_support/hash_with_indifferent_access'
 
 require "apipie/routing"


### PR DESCRIPTION
Ruby 1.9+ ships json in the standard library, so a dependency on the
gem isn't necessary. See also rails/rails@f3433f7c.
