### PR TITLE
Fix Array validator

### DIFF
--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -190,9 +190,10 @@ module Apipie
 
       def enum
         if @items_enum.kind_of?(Proc)
-          @items_enum = Array(@items_enum.call)
+          Array(@items_enum.call)
+        else
+          @items_enum
         end
-        @items_enum
       end
 
       def validate_item(value)


### PR DESCRIPTION
Currently if the `@items_enum` is a lambda function, it will erase itself with its call's value the first time it is called. Instead just called it each time.
