### PR TITLE
Fix json documentation generation.

### DIFF
--- a/lib/apipie/param_description.rb
+++ b/lib/apipie/param_description.rb
@@ -206,7 +206,7 @@ module Apipie
     end
 
     def preformat_text(text)
-      concern_subst(Apipie.markup_to_html(text || ''))
+      concern_subst(text || '')
     end
 
     def is_required?


### PR DESCRIPTION
Before it was translating json from html, which could cause characters like ' to be translated to \&#39; instead of being properly translated. 