### PR TITLE
Fix route discovery with api! for Rails 5

### DIFF
--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -54,14 +54,9 @@ module Apipie
     # the app might be nested when using contraints, namespaces etc.
     # this method does in depth search for the route controller
     def route_app_controller(app, route, visited_apps = [])
-      visited_apps << app
-      if app.respond_to?(:controller)
-        return app.controller(route.defaults)
-      elsif app.respond_to?(:app) && !visited_apps.include?(app.app)
-        return route_app_controller(app.app, route, visited_apps)
+      if route.defaults[:controller]
+        (route.defaults[:controller].camelize + "Controller").constantize
       end
-    rescue ActionController::RoutingError
-      # some errors in the routes will not stop us here: just ignoring
     end
 
     def routes_for_action(controller, method, args)


### PR DESCRIPTION
Since rails deprecated some behavior that the old code depended on, we
just change it to match what its been doing under the hood all along and
avoid having to do a depth first search at the same time.

See https://github.com/rails/rails/commit/4276b214f8a13a38ac7dc4911e90d295a8e40d5a#diff-ccdef70ce0e95afc8816f47f89b56c60 for the commit that caused the regression...
