### PR TITLE
Headers act more like params

### DIFF
--- a/lib/apipie/extractor/writer.rb
+++ b/lib/apipie/extractor/writer.rb
@@ -122,7 +122,18 @@ module Apipie
           new_example_ordered = ordered_call(new_example.dup)
 
           # Comparing verb, versions and query
-          if old_example = old_examples.find{ |old_example| old_example["verb"] == new_example_ordered["verb"] && old_example["versions"] == new_example_ordered["versions"] && old_example["query"] == new_example_ordered["query"]}
+          filtered_old_examples = old_examples.find_all{ |old_example| old_example["verb"] == new_example_ordered["verb"] && old_example["versions"] == new_example_ordered["versions"] && old_example["query"] == new_example_ordered["query"]}
+          if filtered_old_examples.any?
+            most_intersections = 0
+            most_similar = filtered_old_examples[0]
+            filtered_old_examples.each do |old|
+              intersection = (old.deep_symbolize_keys.to_a & new_example.deep_symbolize_keys.to_a).length
+              if intersection > most_intersections
+                most_intersections = intersection
+                most_similar = old
+              end
+            end
+            old_example = most_similar
 
             # Take the 'show in doc' attribute from the old example if it is present and the configuration requests the value to be persisted.
             new_example[:show_in_doc] = old_example["show_in_doc"] if Apipie.configuration.persist_show_in_doc && old_example["show_in_doc"].to_i > 0
@@ -131,7 +142,7 @@ module Apipie
             new_example[:title] ||= old_example["title"] if old_example["title"].present?
           end
           new_example
-        end 
+        end
       end
 
       def load_new_examples

--- a/lib/apipie/method_description.rb
+++ b/lib/apipie/method_description.rb
@@ -49,6 +49,7 @@ module Apipie
       end
       @params_ordered = ParamDescription.unify(@params_ordered)
       @headers = dsl_data[:headers]
+      @headers = all_headers
 
       @show = if dsl_data.has_key? :show
         dsl_data[:show]
@@ -79,6 +80,24 @@ module Apipie
 
       merge_params(all_params, @params_ordered)
       all_params.find_all(&:validator)
+    end
+
+    def all_headers
+      all_headers = []
+      parent = Apipie.get_resource_description(@resource.controller.superclass)
+      # get params from parent resource description
+      [parent, @resource].compact.each do |resource|
+        resource_headers = resource._headers
+        merge_headers(all_headers, resource_headers)
+      end
+
+      merge_headers(all_headers, @headers)
+    end
+
+    def merge_headers(headers, new_headers)
+      new_header_names = Set.new(new_headers.map{ |h| h[:name] })
+      headers.delete_if { |h| new_header_names.include?(h[:name]) }
+      headers.concat(new_headers)
     end
 
     def errors

--- a/lib/apipie/resource_description.rb
+++ b/lib/apipie/resource_description.rb
@@ -108,8 +108,7 @@ module Apipie
         :version => _version,
         :formats => @_formats,
         :metadata => @_metadata,
-        :methods => methods,
-        :headers => _headers
+        :methods => methods
       }
     end
 


### PR DESCRIPTION
Headers set from a resource_description are now inherited in each of the resource's methods, and are no longer displayed under resource.

# Example:
```ruby
resource_description do
  short 'Test case data'
  formats ['json']
  header 'X-API-EMAIL', 'user\'s email', required: 
  header 'X-API-TOKEN', 'user\'s current authentication token', required: true
end
```

Used to show:
![screen shot 2016-07-07 at 10 53 46 am](https://cloud.githubusercontent.com/assets/7122182/16657672/4b6d1778-4431-11e6-8df9-55a80de4504f.png)


It now looks like:
![screen shot 2016-07-07 at 10 52 39 am](https://cloud.githubusercontent.com/assets/7122182/16657668/477038e4-4431-11e6-93a8-11a6cc427388.png)
where every method of document shows the headers.