### PR TITLE
Intelligently pick which old example to copy from

### DIFF
--- a/lib/apipie/method_description.rb
+++ b/lib/apipie/method_description.rb
@@ -49,6 +49,7 @@ module Apipie
       end
       @params_ordered = ParamDescription.unify(@params_ordered)
       @headers = dsl_data[:headers]
+      @headers = all_headers
 
       @show = if dsl_data.has_key? :show
         dsl_data[:show]
@@ -79,6 +80,24 @@ module Apipie
 
       merge_params(all_params, @params_ordered)
       all_params.find_all(&:validator)
+    end
+
+    def all_headers
+      all_headers = []
+      parent = Apipie.get_resource_description(@resource.controller.superclass)
+      # get params from parent resource description
+      [parent, @resource].compact.each do |resource|
+        resource_headers = resource._headers
+        merge_headers(all_headers, resource_headers)
+      end
+
+      merge_headers(all_headers, @headers)
+    end
+
+    def merge_headers(headers, new_headers)
+      new_header_names = Set.new(new_headers.map{ |h| h[:name] })
+      headers.delete_if { |h| new_header_names.include?(h[:name]) }
+      headers.concat(new_headers)
     end
 
     def errors

--- a/lib/apipie/resource_description.rb
+++ b/lib/apipie/resource_description.rb
@@ -108,8 +108,7 @@ module Apipie
         :version => _version,
         :formats => @_formats,
         :metadata => @_metadata,
-        :methods => methods,
-        :headers => _headers
+        :methods => methods
       }
     end
 


### PR DESCRIPTION
Previously, if there were multiple examples with matching verb, version, and query, the title and show_in_doc settings would be copied over to new examples from the first old example. Now it picks it based on which old example is most similar.