### PR TITLE
Headers shown in methods

### DIFF
--- a/lib/apipie/method_description.rb
+++ b/lib/apipie/method_description.rb
@@ -49,6 +49,7 @@ module Apipie
       end
       @params_ordered = ParamDescription.unify(@params_ordered)
       @headers = dsl_data[:headers]
+      @headers = all_headers
 
       @show = if dsl_data.has_key? :show
         dsl_data[:show]
@@ -79,6 +80,24 @@ module Apipie
 
       merge_params(all_params, @params_ordered)
       all_params.find_all(&:validator)
+    end
+
+    def all_headers
+      all_headers = []
+      parent = Apipie.get_resource_description(@resource.controller.superclass)
+      # get params from parent resource description
+      [parent, @resource].compact.each do |resource|
+        resource_headers = resource._headers
+        merge_headers(all_headers, resource_headers)
+      end
+
+      merge_headers(all_headers, @headers)
+    end
+
+    def merge_headers(headers, new_headers)
+      new_header_names = Set.new(new_headers.map{ |h| h[:name] })
+      headers.delete_if { |h| new_header_names.include?(h[:name]) }
+      headers.concat(new_headers)
     end
 
     def errors

--- a/lib/apipie/resource_description.rb
+++ b/lib/apipie/resource_description.rb
@@ -108,8 +108,7 @@ module Apipie
         :version => _version,
         :formats => @_formats,
         :metadata => @_metadata,
-        :methods => methods,
-        :headers => _headers
+        :methods => methods
       }
     end
 


### PR DESCRIPTION
Reposting #469 with the right branch

Headers set from a resource_description are now inherited in each of the resource's methods, and are no longer displayed under resource.

# Example:
```ruby
resource_description do
  short 'Test case data'
  formats ['json']
  header 'X-API-EMAIL', 'user\'s email', required: 
  header 'X-API-TOKEN', 'user\'s current authentication token', required: true
end
```

Used to show:
![screen shot 2016-07-07 at 10 53 46 am](https://cloud.githubusercontent.com/assets/7122182/16657672/4b6d1778-4431-11e6-8df9-55a80de4504f.png)


It now looks like:
![screen shot 2016-07-07 at 10 52 39 am](https://cloud.githubusercontent.com/assets/7122182/16657668/477038e4-4431-11e6-93a8-11a6cc427388.png)
where every method of document shows the headers.