### PR TITLE
ArgumentError: string contains null byte

### DIFF
--- a/lib/apipie/static_dispatcher.rb
+++ b/lib/apipie/static_dispatcher.rb
@@ -8,9 +8,10 @@ module Apipie
     end
 
     def match?(path)
-      path = path.dup
+      # Replace all null bytes
+      path = ::Rack::Utils.unescape(path || '').gsub(/\x0/, '')
 
-      full_path = path.empty? ? @root : File.join(@root, ::Rack::Utils.unescape(path))
+      full_path = path.empty? ? @root : File.join(@root, path)
       paths = "#{full_path}#{ext}"
 
       matches = Dir[paths]

--- a/spec/lib/file_handler_spec.rb
+++ b/spec/lib/file_handler_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe Apipie::FileHandler do
+
+  describe "match?" do
+    let(:file_handler) { Apipie::FileHandler.new File.dirname(__FILE__) }
+
+    it { expect(file_handler.match? 'file_handler_spec.rb').to be_truthy }
+    it { expect(file_handler.match? 'foo.bar').to be_falsy }
+
+    context 'path contains null bytes' do
+      let(:path) { "foo%00.bar" }
+
+      it { expect(file_handler.match? path).to be_falsy }
+      it { expect { file_handler.match? path }.to_not raise_error }
+    end
+  end
+end


### PR DESCRIPTION
Hook for `ArgumentError: string contains null byte`.

Example:

```
GET https://example.com/foo/bar%00.jpg

Traceback:

ArgumentError: string contains null byte

1 File "/app/vendor/bundle/ruby/2.3.0/gems/apipie-rails-0.3.6/lib/apipie/static_dispatcher.rb" line 13 in join
2 File "/app/vendor/bundle/ruby/2.3.0/gems/apipie-rails-0.3.6/lib/apipie/static_dispatcher.rb" line 13 in match?
3 File "/app/vendor/bundle/ruby/2.3.0/gems/apipie-rails-0.3.6/lib/apipie/static_dispatcher.rb" line 59 in call
```
