### PR TITLE
Fix a RuntimeError

### DIFF
--- a/app/controllers/apipie/apipies_controller.rb
+++ b/app/controllers/apipie/apipies_controller.rb
@@ -115,8 +115,8 @@ module Apipie
     def get_format
       [:resource, :method, :version].each do |par|
         if params[par]
-          params[:format] = :html unless params[par].sub!('.html', '').nil?
-          params[:format] = :json unless params[par].sub!('.json', '').nil?
+          params[:format] = :html if params[par].to_s.end_with?('.html')
+          params[:format] = :json if params[par].to_s.end_with?('.json')
         end
       end
       request.format = params[:format] if params[:format]


### PR DESCRIPTION
Fix a RuntimeError:
```
RuntimeError: can't modify frozen String
/Users/tumayun/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/apipie-rails-0.3.6/app/controllers/apipie/apipies_controller.rb:118:in `sub!'
/Users/tumayun/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/apipie-rails-0.3.6/app/controllers/apipie/apipies_controller.rb:118:in `block in get_format'
/Users/tumayun/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/apipie-rails-0.3.6/app/controllers/apipie/apipies_controller.rb:116:in `each'
/Users/tumayun/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/apipie-rails-0.3.6/app/controllers/apipie/apipies_controller.rb:116:in `get_format'
/Users/tumayun/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/apipie-rails-0.3.6/app/controllers/apipie/apipies_controller.rb:20:in `index'
/Users/tumayun/.rvm/gems/ruby-2.3.1/gems/actionpack-5.0.0/lib/action_controller/metal/basic_implicit_render.rb:4:in `send_action'
/Users/tumayun/.rvm/gems/ruby-2.3.1/gems/actionpack-5.0.0/lib/abstract_controller/base.rb:188:in `process_action'
/Users/tumayun/.rvm/gems/ruby-2.3.1/gems/actionpack-5.0.0/lib/action_controller/metal/rendering.rb:30:in `process_action'
/Users/tumayun/.rvm/gems/ruby-2.3.1/gems/actionpack-5.0.0/lib/abstract_controller/callbacks.rb:20:in `block in process_action'
/Users/tumayun/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0/lib/active_support/callbacks.rb:126:in `call'
/Users/tumayun/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0/lib/active_support/callbacks.rb:506:in `block (2 levels) in compile'
/Users/tumayun/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0/lib/active_support/callbacks.rb:455:in `call'
/Users/tumayun/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0/lib/active_support/callbacks.rb:448:in `block (2 levels) in around'
/Users/tumayun/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0/lib/active_support/callbacks.rb:286:in `block (2 levels) in halting'
/Users/tumayun/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/apipie-rails-0.3.6/app/controllers/apipie/apipies_controller.rb:163:in `set_script_name'
/Users/tumayun/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0/lib/active_support/callbacks.rb:382:in `block in make_lambda'
/Users/tumayun/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0/lib/active_support/callbacks.rb:285:in `block in halting'
/Users/tumayun/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0/lib/active_support/callbacks.rb:447:in `block in around'
/Users/tumayun/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0/lib/active_support/callbacks.rb:455:in `call'
/Users/tumayun/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
/Users/tumayun/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0/lib/active_support/callbacks.rb:750:in `_run_process_action_callbacks'
/Users/tumayun/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0/lib/active_support/callbacks.rb:90:in `run_callbacks'
```