### PR TITLE
fixed to_json encoding error that occurs with uploaded file parameters

### DIFF
--- a/lib/apipie/extractor/writer.rb
+++ b/lib/apipie/extractor/writer.rb
@@ -77,20 +77,22 @@ module Apipie
         ordered_call = OrderedHash.new
         %w[title verb path versions query request_data response_data code show_in_doc recorded].each do |k|
           next unless call.has_key?(k)
-          ordered_call[k] = case call[k]
-                       when ActiveSupport::HashWithIndifferentAccess
-                         # UploadedFiles break the to_json call, turn them into a string so they don't break
-                         call[k].each do |pkey, pval|
-                           if (pval.is_a?(Rack::Test::UploadedFile) || pval.is_a?(ActionDispatch::Http::UploadedFile))
-                             call[k][pkey] = "<FILE CONTENT '#{pval.original_filename}'>"
-                           end
-                         end
-                         JSON.parse(call[k].to_json) # to_hash doesn't work recursively and I'm too lazy to write the recursion:)
-                       else
-                         call[k]
-                       end
+          ordered_call[k] = preserve_call call[k]
         end
         return ordered_call
+      end
+
+      def preserve_call call
+        if call.is_a?(Rack::Test::UploadedFile) || call.is_a?(ActionDispatch::Http::UploadedFile)
+          "<FILE CONTENT '#{call.original_filename}'>"
+        elsif call.is_a? ActiveSupport::HashWithIndifferentAccess
+          call.each do |pkey, pval|
+            call[pkey] = preserve_call pval
+          end
+          JSON.parse(call.to_json)
+        else
+          call
+        end
       end
 
       def load_recorded_examples


### PR DESCRIPTION
Fix for #296 issue. It is almost the same as #429 but it parses params recursively. Works for Rails 5 now.