### PR TITLE
Custom Class Name to Camelize paths properly 

### DIFF
--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -410,6 +410,9 @@ module Apipie
 
     def load_controller_from_file(controller_file)
       controller_class_name = controller_file.gsub(/\A.*\/app\/controllers\//,"").gsub(/\.\w*\Z/,"").camelize
+      Apipie.configuration.custom_class_name.each do |k, v|
+        controller_class_name.gsub!(k, v)
+      end
       controller_class_name.constantize
     end
 

--- a/lib/apipie/configuration.rb
+++ b/lib/apipie/configuration.rb
@@ -34,6 +34,11 @@ module Apipie
     # from this class and override the methods as needed.
     attr_accessor :routes_formatter
 
+    # Custom class name allows for substitution when camelizing & constantizing a string from the path
+    # in load_controller_from_file. Example, a path /api would be camelized as ::Api while the actual module
+    # could be ::API. By setting { 'Api' => 'API' }, it would correct this disconnect.
+    attr_accessor :custom_class_name
+
     def reload_controllers?
       @reload_controllers = Rails.env.development? unless defined? @reload_controllers
       return @reload_controllers && @api_controllers_matcher
@@ -165,6 +170,7 @@ module Apipie
       @translate = lambda { |str, locale| str }
       @persist_show_in_doc = false
       @routes_formatter = RoutesFormatter.new
+      @custom_class_name = {}
     end
   end
 end


### PR DESCRIPTION
I recently came across an issue when loading api pie in my application with the camelizing and constantizing of the path names in `load_controller_from_file`.

The path that was being loaded was `app/controllers/appname/api` which was being camelized as `App::Appname::Api`, but the actual controller module is `App::Appname::API`. I was unable to find a solution that already existed through configurations (although please correct me if I'm wrong) so I came up with a simple solution of allowing substitutions. I am willing to work to find a more elegant solution to this problem.

I am not sure if anybody else has had this issue or if it's relevant for others. 

With this minor change, my configuration became:
```
Apipie.configure do |config|
  config.api_controllers_matcher = "#{Rails.root}/app/controllers/appname/**/*.rb"
  config.custom_class_name       = { 'Api' => 'API' }
end
```