### PR TITLE
Fix example recording when using send_file

### DIFF
--- a/lib/apipie/extractor/recorder.rb
+++ b/lib/apipie/extractor/recorder.rb
@@ -28,7 +28,11 @@ module Apipie
 
       def analyse_response(response)
         if response.last.respond_to?(:body) && data = parse_data(response.last.body)
-          @response_data = data
+          @response_data = if response[1]['Content-Disposition'].to_s.start_with?('attachment')
+                             '<STREAMED ATTACHMENT FILE>'
+                           else
+                             data
+                           end
         end
         @code = response.first
       end


### PR DESCRIPTION
When recording an example of a controller that calls [`send_file`](http://api.rubyonrails.org/classes/ActionController/DataStreaming.html#method-i-send_file), I'm getting this exception because of the binary content:

```
Writing examples to a file
/home/vagrant/pricematch/admin/vendor/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:34:in `encode': "\xEC" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)
	from /home/vagrant/pricematch/admin/vendor/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:34:in `to_json'
	from /home/vagrant/pricematch/admin/vendor/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:34:in `to_json_with_active_support_encoder'
	from /home/vagrant/pricematch/admin/vendor/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:34:in `to_json'
	from /home/vagrant/pricematch/admin/vendor/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:34:in `to_json_with_active_support_encoder'
	from /home/vagrant/pricematch/admin/vendor/ruby/2.2.0/gems/json-1.8.3/lib/json/common.rb:285:in `generate'
	from /home/vagrant/pricematch/admin/vendor/ruby/2.2.0/gems/json-1.8.3/lib/json/common.rb:285:in `pretty_generate'
	from /home/vagrant/pricematch/admin/vendor/ruby/2.2.0/gems/apipie-rails-0.3.4/lib/apipie/extractor/writer.rb:43:in `block in write_recorded_examples'
	from /home/vagrant/pricematch/admin/vendor/ruby/2.2.0/gems/apipie-rails-0.3.4/lib/apipie/extractor/writer.rb:42:in `open'
	from /home/vagrant/pricematch/admin/vendor/ruby/2.2.0/gems/apipie-rails-0.3.4/lib/apipie/extractor/writer.rb:42:in `write_recorded_examples'
	from /home/vagrant/pricematch/admin/vendor/ruby/2.2.0/gems/apipie-rails-0.3.4/lib/apipie/extractor/writer.rb:13:in `write_examples'
	from /home/vagrant/pricematch/admin/vendor/ruby/2.2.0/gems/apipie-rails-0.3.4/lib/apipie/extractor.rb:78:in `write_examples'
	from /home/vagrant/pricematch/admin/vendor/ruby/2.2.0/gems/apipie-rails-0.3.4/lib/apipie/extractor.rb:46:in `finish'
	from /home/vagrant/pricematch/admin/vendor/ruby/2.2.0/gems/apipie-rails-0.3.4/lib/apipie/extractor.rb:179:in `block in <top (required)>'
```

This PR fixes it, at least for me (I'm just replacing the binary contents by a placeholder string)