### PR TITLE
Include relative_url_root if set in the environment file

### DIFF
--- a/lib/apipie/helpers.rb
+++ b/lib/apipie/helpers.rb
@@ -28,6 +28,7 @@ module Apipie
       path = path.sub(/^\//,"")
       ret = "#{@url_prefix}/#{path}"
       ret.insert(0,"/") unless ret =~ /\A[.\/]/
+      ret.insert(0,Rails.application.config.relative_url_root) unless Rails.application.config.relative_url_root.nil?
       ret.sub!(/\/*\Z/,"")
       ret
     end


### PR DESCRIPTION
Our project uses the environment config option 'relative_url_root'. So my project url is something like https://my_company.com/my_project. The docs are always defaulting to the base url https://my_company.com. This pull request will include the relative_url_root if given.