### PR TITLE
Allow a blank, not just nil, base_url.

### DIFF
--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -392,7 +392,7 @@ module Apipie
     def version_prefix(klass)
       version = controller_versions(klass).first
       base_url = get_base_url(version)
-      return "/" if base_url.nil?
+      return "/" if base_url.blank?
       base_url[1..-1] + "/"
     end
 


### PR DESCRIPTION
I changed my api_base_url from '/api' to '' and had document generation fail because only nil base_urls were allowed.  This relaxes that and allows a blank base_url.