### PR TITLE
Fix #522

### DIFF
--- a/lib/apipie/extractor/recorder.rb
+++ b/lib/apipie/extractor/recorder.rb
@@ -41,7 +41,7 @@ module Apipie
         if [:POST, :PUT, :PATCH].include?(@verb)
           @request_data = @params
         else
-          @query = request.query_string
+          @path = request.fullpath
         end
         @response_data = parse_data(response.body)
         @code = response.code


### PR DESCRIPTION
 Parameters for GET requests in tests do not appear in docu…mentation

Change the recorder to take the query string and path together using fullpath
for GET requests.  request.query_string was blank in my usage and debugging
sessions.  The query string was available as request.fullpath or
request.env['rack.request.query_string']