### PR TITLE
Include delete request parmeters in generated documentation

### DIFF
--- a/lib/apipie/extractor/recorder.rb
+++ b/lib/apipie/extractor/recorder.rb
@@ -38,7 +38,7 @@ module Apipie
         @verb = request.request_method.to_sym
         @path = request.path
         @params = request.request_parameters
-        if [:POST, :PUT, :PATCH].include?(@verb)
+        if [:POST, :PUT, :PATCH, :DELETE].include?(@verb)
           @request_data = @params
         else
           @query = request.query_string


### PR DESCRIPTION
One of my API routes allows multiple objects to be deleted.  In routing, it
looks like this:

```ruby
  resources :posts do
    collection do
        delete :destroy
      end
  end
```

The generated examples from tests did not include the parameters.  This patch
treats :DELETE like PUT/POST/PATCH and includes the parameters in the generated
examples.