### PR TITLE
constantize controller class before calling superclass

### DIFF
--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -126,7 +126,7 @@ module Apipie
       if controller == ActionController::Base || controller.nil?
         return [Apipie.configuration.default_version]
       else
-        return controller_versions(controller.superclass)
+        return controller_versions(controller.to_s.constantize.superclass)
       end
     end
 


### PR DESCRIPTION
The commit 69c5bdcf51cb0d6a73a6cbf75dc4f58097f1f7e0 introduced calling _superclass_ on strings due to the fact that @controller_versions is now holding only the controller name as a string instead of the controller class itself. Due to this situation the 0.5.3 release is broken for me.

```
/Users/fl/.rvm/gems/ruby-2.4.1/gems/apipie-rails-0.5.3/lib/apipie/application.rb:129:in `controller_versions': undefined method `superclass' for "V1::ApplicationController":String (NoMethodError)
	from /Users/fl/.rvm/gems/ruby-2.4.1/gems/apipie-rails-0.5.3/lib/apipie/application.rb:388:in `version_prefix'
	from /Users/fl/.rvm/gems/ruby-2.4.1/gems/apipie-rails-0.5.3/lib/apipie/application.rb:346:in `get_resource_name'
	from /Users/fl/.rvm/gems/ruby-2.4.1/gems/apipie-rails-0.5.3/lib/apipie/application.rb:104:in `define_resource_description'
	from /Users/fl/.rvm/gems/ruby-2.4.1/gems/apipie-rails-0.5.3/lib/apipie/apipie_module.rb:18:in `method_missing'
	from /Users/fl/.rvm/gems/ruby-2.4.1/gems/apipie-rails-0.5.3/lib/apipie/dsl_definition.rb:145:in `block in resource_description'
	from /Users/fl/.rvm/gems/ruby-2.4.1/gems/apipie-rails-0.5.3/lib/apipie/dsl_definition.rb:144:in `map'
	from /Users/fl/.rvm/gems/ruby-2.4.1/gems/apipie-rails-0.5.3/lib/apipie/dsl_definition.rb:144:in `resource_description'
	from /Users/fl/XXX/app/controllers/v1/application_controller.rb:4:in `<class:ApplicationController>'
```