### PR TITLE
Allow for resource-level deprecations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,6 +136,9 @@ app_info
 meta
   Hash or array with custom metadata.
 
+deprecated
+  Boolean value indicating if the resource is marked as deprecated. (Default false)
+
 Example:
 ~~~~~~~~
 
@@ -154,6 +157,7 @@ Example:
      error 500, "Server crashed for some <%= reason %>", :meta => {:anything => "you can think of"}
      error :unprocessable_entity, "Could not save the entity."
      meta :author => {:name => 'John', :surname => 'Doe'}
+     deprecated false
      description <<-EOS
        == Long description
         Example resource for rest api documentation

--- a/app/views/apipie/apipies/index.html.erb
+++ b/app/views/apipie/apipies/index.html.erb
@@ -16,7 +16,11 @@
   <h2>
     <a href='<%= api[:doc_url] %><%= @doc[:link_extension] %>'>
       <%= api[:name] %>
-    </a><br>
+    </a>
+    <% if api[:deprecated] %>
+        <code>DEPRECATED</code>
+    <% end %>
+    <br>
     <small><%= api[:short_description] %></small>
   </h2>
   <table class='table'>

--- a/app/views/apipie/apipies/resource.html.erb
+++ b/app/views/apipie/apipies/resource.html.erb
@@ -13,6 +13,9 @@
 <div class='page-header'>
   <h1>
     <%= @resource[:name] %>
+    <% if @resource[:deprecated] %>
+        <code>DEPRECATED</code>
+    <% end %>
     <br>
     <small><%= raw @resource[:short_description] %></small>
   </h1>

--- a/lib/apipie/dsl_definition.rb
+++ b/lib/apipie/dsl_definition.rb
@@ -42,7 +42,8 @@ module Apipie
          :formats           => nil,
          :api_versions      => [],
          :meta              => nil,
-         :show              => true
+         :show              => true,
+         :deprecated        => false
        }
       end
     end
@@ -76,6 +77,11 @@ module Apipie
       def app_info(app_info)
         _apipie_dsl_data[:app_info] = app_info
       end
+
+      def deprecated(value)
+        _apipie_dsl_data[:deprecated] = value
+      end
+
     end
 
     module Action

--- a/lib/apipie/method_description.rb
+++ b/lib/apipie/method_description.rb
@@ -129,7 +129,7 @@ module Apipie
           :api_url => create_api_url(api),
           :http_method => api.http_method.to_s,
           :short_description => Apipie.app.translate(api.short_description, lang),
-          :deprecated => api.options[:deprecated]
+          :deprecated => resource._deprecated || api.options[:deprecated]
         }
       end
     end

--- a/lib/apipie/resource_description.rb
+++ b/lib/apipie/resource_description.rb
@@ -10,11 +10,12 @@ module Apipie
   # id - resouce name
   # formats - acceptable request/response format types
   # headers - array of headers
+  # deprecated - boolean indicating if resource is deprecated
   class ResourceDescription
 
     attr_reader :controller, :_short_description, :_full_description, :_methods, :_id,
       :_path, :_name, :_params_args, :_errors_args, :_formats, :_parent, :_metadata,
-      :_headers
+      :_headers, :_deprecated
 
     def initialize(controller, resource_name, dsl_data = nil, version = nil, &block)
 
@@ -42,6 +43,7 @@ module Apipie
       @_metadata = dsl_data[:meta]
       @_api_base_url = dsl_data[:api_base_url]
       @_headers = dsl_data[:headers]
+      @_deprecated = dsl_data[:deprecated] || false
 
       if dsl_data[:app_info]
         Apipie.configuration.app_info[_version] = dsl_data[:app_info]
@@ -109,7 +111,8 @@ module Apipie
         :formats => @_formats,
         :metadata => @_metadata,
         :methods => methods,
-        :headers => _headers
+        :headers => _headers,
+        :deprecated => @_deprecated
       }
     end
 

--- a/spec/lib/method_description_spec.rb
+++ b/spec/lib/method_description_spec.rb
@@ -36,6 +36,13 @@ describe Apipie::MethodDescription do
       method = Apipie::MethodDescription.new(:a, @resource, dsl_data)
       expect(method.method_apis_to_json.first[:deprecated]).to eq(true)
     end
+
+    it "should return the deprecated flag if resource is deprecated" do
+      @resource.instance_variable_set("@_deprecated", true)
+      dsl_data[:api_args] = [[:GET, "/foo/bar", "description", {}]]
+      method = Apipie::MethodDescription.new(:a, @resource, dsl_data)
+      expect(method.method_apis_to_json.first[:deprecated]).to eq(true)
+    end
   end
 
   describe "params descriptions" do


### PR DESCRIPTION
Resources can now be marked as deprecated. 
This marking is also referenced at the method level, meaning that resources marked as
deprecated will have all their methods marked as such as well.

This commit also includes related updates to the views used for
generating documentation