### PR TITLE
Added Swagger generation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1243,6 +1243,16 @@ Known limitations of the current implementation
 * It is not possible to leverage all of the parameter type/format capabilities of swagger
 * Only OpenAPI 2.0 is supported
 
+====================================
+ Dynamic Swagger generation
+====================================
+
+To generate swagger dynamically, use ``http://localhost:3000/apipie.json?type=swagger``.
+
+Note that authorization is not supported for dynamic swagger generation, so if ``config.authorize`` is defined,
+dynamic swagger generation will be disabled.
+
+Dynamically generated swagger is not cached, and is always generated on the fly.
 
 
 ===================

--- a/README.rst
+++ b/README.rst
@@ -1184,6 +1184,7 @@ it identifies various shortcomings of the DSL documentation. Each warning has a 
 :105: a parameter is optional but does not have a default value specified
 :106: a parameter was ommitted from the swagger output because it is a Hash without fields in a formData specification
 :107: a path parameter is not described
+:108: inferring that a parameter type is boolean because described as an enum with [false,true] values
 
 
 
@@ -1223,6 +1224,13 @@ There are several configuration parameters that determine the structure of the g
     If ``true``: all warnings will be suppressed
 
     If an array of values (e.g., ``[100,102,107]``), only the warnings identified by the numbers in the array will be suppressed.
+
+``config.swagger_api_host``
+    The value to place in the swagger host field.
+
+    Default is ``localhost:3000``
+
+    If ``nil`` then then host field will not be included.
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -1150,6 +1150,93 @@ If, for some complex cases, you need to generate/re-generate just part of the ca
 use ``rake apipie:cache cache_part=index`` resp. ``rake apipie:cache cache_part=resources``
 To generate it for different locations for further processing use ``rake apipie:cache OUT=/tmp/apipie_cache``.
 
+====================================
+ Static Swagger (OpenAPI 2.0) files
+====================================
+
+To generate a static Swagger definition file from the api, run ``rake apipie:static_swagger_json``.
+By default the documentation for the default API version is
+used. You can specify the version with ``rake apipie:static_swagger_json[2.0]``. A swagger file will be
+generated for each locale.  The files will be generated in the same location as the static_json files, but
+instead of being named ``schema_apipie[.locale].json``, they will be called ``schema_swagger[.locale].json``.
+
+Specifying default values for parameters
+-----------------------------------------
+Swagger allows method definitions to include an indication of the the default value for each parameter. To include such
+indications, use ``:default_value => <some value>`` in the parameter definition DSL.  For example:
+
+.. code:: ruby
+
+     param :do_something, Boolean, :desc => "take an action", :required => false, :default_value => false
+
+
+Generated Warnings
+-------------------
+The help identify potential improvements to your documentation, the swagger generation process issues warnings if
+it identifies various shortcomings of the DSL documentation. Each warning has a code to allow selective suppression
+(see swagger-specific configuration below)
+
+:100: missing short description for method
+:101: added missing / at beginning of path
+:102: no return codes specified for method
+:103: a parameter is a generic Hash without an internal type specification
+:104: a parameter is an 'in-path' parameter, but specified as 'not required' in the DSL
+:105: a parameter is optional but does not have a default value specified
+:106: a parameter was ommitted from the swagger output because it is a Hash without fields in a formData specification
+:107: a path parameter is not described
+
+
+
+Swagger-Specific Configuration Parameters
+-------------------------------------------------
+
+There are several configuration parameters that determine the structure of the generated swagger file:
+
+``config.swagger_content_type_input``
+    If the value is ``:form_data`` - the swagger file will indicate that the server consumes the content types
+    ``application/x-www-form-urlencoded`` and ``multipart/form-data``.  Non-path parameters will have the
+    value ``"in": "formData"``.  Note that parameters of type Hash that do not have any fields in them will *be ommitted*
+    from the resulting files, as there is no way to describe them in swagger.
+
+    If the value is ``:json`` - the swagger file will indicate that the server consumes the content type
+    ``application/json``. All non-path parameters will be included in the schema of a single ``"in": "body"`` parameter
+    of type ``object``.
+
+    You can specify the value of this configuration parameter as an additional input to the rake command (e.g.,
+    ``rake apipie:static_swagger_json[2.0,form_data]``).
+
+``config.swagger_json_input_uses_refs``
+    This parameter is only relevant if ``swagger_content_type_input`` is ``:json``.
+
+    If ``true``: the schema of the ``"in": "body"`` parameter of each method is given its own entry in the ``definitions``
+    section, and is referenced using ``$ref`` from the method definition.
+
+    If ``false``: the body parameter definitions are inlined within the method definitions.
+
+``config.swagger_include_warning_tags``
+    If ``true``: in addition to tagging methods with the name of the resource they belong to, methods for which warnings
+    have been issued will be tagged with.
+
+``config.swagger_suppress_warnings``
+    If ``false``: no warnings will be suppressed
+
+    If ``true``: all warnings will be suppressed
+
+    If an array of values (e.g., ``[100,102,107]``), only the warnings identified by the numbers in the array will be suppressed.
+
+
+
+Known limitations of the current implementation
+-------------------------------------------------
+* There is currently no way to document the structure and content-type of the data returned from a method
+* Recorded examples are currently not included in the generated swagger file
+* The apipie ``formats`` value is ignored.
+* It is not possible to specify the "consumed" content type on a per-method basis
+* It is not possible to leverage all of the parameter type/format capabilities of swagger
+* Only OpenAPI 2.0 is supported
+
+
+
 ===================
  JSON checksums
 ===================

--- a/apipie-rails.gemspec
+++ b/apipie-rails.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "RedCloth"
   s.add_development_dependency "rake"
   s.add_development_dependency "rdoc"
+  s.add_development_dependency "json-schema", "~> 2.8"
 end

--- a/app/controllers/apipie/apipies_controller.rb
+++ b/app/controllers/apipie/apipies_controller.rb
@@ -15,40 +15,14 @@ module Apipie
     end
 
 
-    def render_swagger_json
-      # the 'authorize' configuration is not supported for swagger output
-      head :forbidden and return if Apipie.configuration.authorize
-
-      @language = get_language
-
-      Apipie.load_documentation if Apipie.configuration.reload_controllers? || (Rails.version.to_i >= 4.0 && !Rails.application.config.eager_load)
-
-      I18n.locale = @language
-
-      prev_warning_value = Apipie.configuration.swagger_suppress_warnings
-      Apipie.configuration.swagger_suppress_warnings = true
-
-      doc = Apipie.to_swagger_json(params[:version], params[:resource], params[:method], @language)
-
-      Apipie.configuration.swagger_suppress_warnings = prev_warning_value
-
-      unless doc
-        render 'apipie_404', :status => 404
-        return
-      end
-
-      render :json => doc
-    end
-
-
     def index
       params[:version] ||= Apipie.configuration.default_version
 
       get_format
 
       if params[:type].to_s == 'swagger' && params[:format].to_s == 'json'
-        render_swagger_json
-        return
+        head :forbidden and return if Apipie.configuration.authorize
+        should_render_swagger = true
       end
 
       respond_to do |format|
@@ -63,9 +37,19 @@ module Apipie
         Apipie.load_documentation if Apipie.configuration.reload_controllers? || (Rails.version.to_i >= 4.0 && !Rails.application.config.eager_load)
 
         I18n.locale = @language
-        @doc = Apipie.to_json(params[:version], params[:resource], params[:method], @language)
 
-        @doc = authorized_doc
+        if should_render_swagger
+          prev_warning_value = Apipie.configuration.swagger_suppress_warnings
+          begin
+            Apipie.configuration.swagger_suppress_warnings = true
+            @doc = Apipie.to_swagger_json(params[:version], params[:resource], params[:method], @language)
+          ensure
+            Apipie.configuration.swagger_suppress_warnings = prev_warning_value
+          end
+        else
+          @doc = Apipie.to_json(params[:version], params[:resource], params[:method], @language)
+          @doc = authorized_doc
+        end
 
         format.json do
           if @doc

--- a/lib/apipie-rails.rb
+++ b/lib/apipie-rails.rb
@@ -17,6 +17,7 @@ require "apipie/validator"
 require "apipie/railtie"
 require 'apipie/extractor'
 require "apipie/version"
+require "apipie/swagger_generator"
 
 if Rails.version.start_with?("3.0")
   warn 'Warning: apipie-rails is not going to support Rails 3.0 anymore in future versions'

--- a/lib/apipie/apipie_module.rb
+++ b/lib/apipie/apipie_module.rb
@@ -13,6 +13,11 @@ module Apipie
     app.to_json(version, resource_name, method_name, lang)
   end
 
+  def self.to_swagger_json(version = nil, resource_name = nil, method_name = nil, lang = nil, clear_warnings=true)
+    version ||= Apipie.configuration.default_version
+    app.to_swagger_json(version, resource_name, method_name, lang, clear_warnings)
+  end
+
   # all calls delegated to Apipie::Application instance
   def self.method_missing(method, *args, &block)
     app.respond_to?(method) ? app.send(method, *args, &block) : super

--- a/lib/apipie/configuration.rb
+++ b/lib/apipie/configuration.rb
@@ -9,14 +9,14 @@ module Apipie
       :link_extension, :record, :languages, :translate, :locale, :default_locale,
       :persist_show_in_doc, :authorize,
       :swagger_include_warning_tags, :swagger_content_type_input, :swagger_json_input_uses_refs,
-      :swagger_suppress_warnings, :swagger_api_host
+      :swagger_suppress_warnings, :swagger_api_host, :swagger_generate_x_computed_id_field
 
     alias_method :validate?, :validate
     alias_method :required_by_default?, :required_by_default
     alias_method :namespaced_resources?, :namespaced_resources
     alias_method :swagger_include_warning_tags?, :swagger_include_warning_tags
     alias_method :swagger_json_input_uses_refs?, :swagger_json_input_uses_refs
-
+    alias_method :swagger_generate_x_computed_id_field?, :swagger_generate_x_computed_id_field
 
     # matcher to be used in Dir.glob to find controllers to be reloaded e.g.
     #
@@ -175,6 +175,7 @@ module Apipie
       @swagger_include_warning_tags = false
       @swagger_suppress_warnings = false #[105,100,102]
       @swagger_api_host = "localhost:3000"
+      @swagger_generate_x_computed_id_field = false
     end
   end
 end

--- a/lib/apipie/configuration.rb
+++ b/lib/apipie/configuration.rb
@@ -7,11 +7,16 @@ module Apipie
       :validate, :validate_value, :validate_presence, :validate_key, :authenticate, :doc_path,
       :show_all_examples, :process_params, :update_checksum, :checksum_path,
       :link_extension, :record, :languages, :translate, :locale, :default_locale,
-      :persist_show_in_doc, :authorize
+      :persist_show_in_doc, :authorize,
+      :swagger_include_warning_tags, :swagger_content_type_input, :swagger_json_input_uses_refs,
+      :swagger_suppress_warnings, :swagger_api_host
 
     alias_method :validate?, :validate
     alias_method :required_by_default?, :required_by_default
     alias_method :namespaced_resources?, :namespaced_resources
+    alias_method :swagger_include_warning_tags?, :swagger_include_warning_tags
+    alias_method :swagger_json_input_uses_refs?, :swagger_json_input_uses_refs
+
 
     # matcher to be used in Dir.glob to find controllers to be reloaded e.g.
     #
@@ -165,6 +170,11 @@ module Apipie
       @translate = lambda { |str, locale| str }
       @persist_show_in_doc = false
       @routes_formatter = RoutesFormatter.new
+      @swagger_content_type_input = :form_data  # this can be :json or :form_data
+      @swagger_json_input_uses_refs = false
+      @swagger_include_warning_tags = false
+      @swagger_suppress_warnings = false #[105,100,102]
+      @swagger_api_host = "localhost:3000"
     end
   end
 end

--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -178,7 +178,7 @@ module Apipie
       if resource._full_description
         @tags << {
             name: tag_name_for_resource(resource),
-            description: resource._full_description
+            description: Apipie.app.translate(resource._full_description, @current_lang)
         }
       end
     end

--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -190,7 +190,7 @@ module Apipie
     def add_ruby_method(paths, ruby_method)
 
       if @only_method
-        return unless ruby_method.name == @only_method
+        return unless ruby_method.method == @only_method
       else
         return if !ruby_method.show
       end

--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -129,7 +129,7 @@ module Apipie
     def warn_optional_without_default_value(param_name) warn 105,"the parameter :#{param_name} is optional but default value is not specified (use :default_value => ...)"; end
     def warn_param_ignored_in_form_data(param_name) warn 106,"ignoring param :#{param_name} -- cannot include Hash without fields in a formData specification"; end
     def warn_path_parameter_not_described(name,path) warn 107,"the parameter :#{name} appears in the path #{path} but is not described"; end
-    def warn_inferring_boolean(name) warn 108,"the parameter [#{param_name}] is Enum with [true,false] values. Inferring 'boolean'"; end
+    def warn_inferring_boolean(name) warn 108,"the parameter [#{name}] is Enum with [true,false] values. Inferring 'boolean'"; end
 
     def warn(warning_num, msg)
       suppress = Apipie.configuration.swagger_suppress_warnings
@@ -257,7 +257,9 @@ module Apipie
     end
 
     def swagger_op_id_for_path(http_method, path)
-      http_method.upcase + path.gsub(/\//,'_').gsub(/:(\w+)/, '\1')
+      # using lowercase http method, because the 'swagger-codegen' tool outputs
+      # strange method names if the http method is in uppercase
+      http_method.downcase + path.gsub(/\//,'_').gsub(/:(\w+)/, '\1').gsub(/_$/,'')
     end
 
     def swagger_param_type(param_desc)

--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -520,7 +520,7 @@ module Apipie
 
       if params_in_body? && body_allowed_for_current_method
         if params_in_body_use_reference?
-          swagger_schema_for_body = {"$ref": gen_referenced_block_from_params_array("#{swagger_op_id_for_method(method)}_input", body_param_defs_array)}
+          swagger_schema_for_body = {"$ref" => gen_referenced_block_from_params_array("#{swagger_op_id_for_method(method)}_input", body_param_defs_array)}
         else
           swagger_schema_for_body = json_schema_obj_from_params_array(body_param_defs_array)
         end

--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -561,7 +561,7 @@ module Apipie
 
         if swagger_param_type(desc) == "object"
           if desc.validator.params_ordered
-            params_hash = desc.validator.params_ordered.map {|desc| [desc.name, desc]}.to_h
+            params_hash = Hash[desc.validator.params_ordered.map {|desc| [desc.name, desc]}]
             add_params_from_hash(swagger_params_array, params_hash, name)
           else
             warn_param_ignored_in_form_data(desc.name)

--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -1,0 +1,583 @@
+module Apipie
+  module Validator
+    class EnumValidator < BaseValidator
+      def values
+        @array
+      end
+    end
+
+    class HashValidator < BaseValidator
+      def get_param_group
+        @param_group
+      end
+    end
+  end
+
+  #--------------------------------------------------------------------------
+  # Configuration.  Should be moved to Apipie config.
+    #--------------------------------------------------------------------------
+  class SwaggerGenerator
+    require 'json'
+    require 'ostruct'
+    require 'open3'
+
+    def initialize(apipie)
+      @apipie = apipie
+    end
+
+    def params_in_body?
+      Apipie.configuration.swagger_content_type_input == :json
+    end
+
+    def params_in_body_use_reference?
+      Apipie.configuration.swagger_json_input_uses_refs
+    end
+
+    def include_warning_tags?
+      Apipie.configuration.swagger_include_warning_tags
+    end
+
+
+    def generate_from_resources(version, resources, method_name, lang, clear_warnings=false)
+      init_swagger_vars(version, lang, clear_warnings)
+
+      @lang = lang
+      @only_method = method_name
+      add_resources(resources)
+
+      return @swagger
+    end
+
+
+    #--------------------------------------------------------------------------
+    # Initialization
+    #--------------------------------------------------------------------------
+
+    def init_swagger_vars(version, lang, clear_warnings=false)
+
+      # docs = {
+      #     :name => Apipie.configuration.app_name,
+      #     :info => Apipie.app_info(version, lang),
+      #     :copyright => Apipie.configuration.copyright,
+      #     :doc_url => Apipie.full_url(url_args),
+      #     :api_url => Apipie.api_base_url(version),
+      #     :resources => _resources
+      # }
+
+      @swagger = {
+          swagger: '2.0',
+          info: {
+              title: "#{Apipie.configuration.app_name}",
+              description: "#{Apipie.app_info(version, lang)}#{Apipie.configuration.copyright}",
+              version: "#{version}",
+              "x-copyright" => Apipie.configuration.copyright,
+          },
+          host: Apipie.configuration.swagger_api_host,
+          basePath: Apipie.api_base_url(version),
+          consumes: [],
+          paths: {},
+          definitions: {},
+          tags: [],
+      }
+
+      if params_in_body?
+        @swagger[:consumes] = ['application/json']
+      else
+        @swagger[:consumes] = ['application/x-www-form-urlencoded', 'multipart/form-data']
+      end
+
+      @paths = @swagger[:paths]
+      @definitions = @swagger[:definitions]
+      @tags = @swagger[:tags]
+
+      @issued_warnings = [] if clear_warnings || @issued_warnings.nil?
+
+      @current_lang = lang
+    end
+
+    #--------------------------------------------------------------------------
+    # Engine interface methods
+    #--------------------------------------------------------------------------
+
+    def add_resources(resources)
+      resources.each do |resource_name, resource_defs|
+        add_resource_description(resource_name, resource_defs)
+        add_resource_methods(resource_name, resource_defs)
+      end
+    end
+
+    def add_resource_methods(resource_name, resource_defs)
+      resource_defs._methods.each do |apipie_method_name, apipie_method_defs|
+        add_ruby_method(@paths, apipie_method_defs)
+      end
+    end
+
+
+    #--------------------------------------------------------------------------
+    # Logging, debugging and regression-testing utilities
+    #--------------------------------------------------------------------------
+
+    def ruby_name_for_method(method)
+      return "<no method>" if method.nil?
+      method.resource.controller.name + "#" + method.method
+    end
+
+
+    def warn_missing_method_summary() warn 100, "missing short description for method"; end
+    def warn_added_missing_slash(path) warn 101,"added missing / at beginning of path: #{path}"; end
+    def warn_no_return_codes_specified()  warn 102,"no return codes ('errors') specified"; end
+    def warn_hash_without_internal_typespec(param_name)  warn 103,"the parameter :#{param_name} is a generic Hash without an internal type specification"; end
+    def warn_optional_param_in_path(param_name) warn 104, "the parameter :#{param_name} is 'in-path'.  Ignoring 'not required' in DSL"; end
+    def warn_optional_without_default_value(param_name) warn 105,"the parameter :#{param_name} is optional but default value is not specified (use :default_value => ...)"; end
+    def warn_param_ignored_in_form_data(param_name) warn 106,"ignoring param :#{param_name} -- cannot include Hash without fields in a formData specification"; end
+    def warn_path_parameter_not_described(name,path) warn 107,"the parameter :#{name} appears in the path #{path} but is not described"; end
+
+
+    def warn(warning_num, msg)
+      suppress = Apipie.configuration.swagger_suppress_warnings
+      return if suppress == true
+      return if suppress.is_a?(Array) && suppress.include?(warning_num)
+
+      method_id = ruby_name_for_method(@current_method)
+      warning_id = "#{method_id}#{warning_num}#{msg}"
+
+      if @issued_warnings.include?(warning_id)
+        # print "--> Already issued warning: [#{warning_id}]\n"
+        return
+      end
+
+      print "WARNING (#{warning_num}): [#{method_id}] -- #{msg}\n"
+      @issued_warnings.push(warning_id)
+      @warnings_issued = true
+    end
+
+    def info(msg)
+      print "--- INFO: [#{ruby_name_for_method(@current_method)}] -- #{msg}\n"
+    end
+
+    def investigate(msg)
+      # print "??? RESEARCH: [#{ruby_name_for_method(@current_method)}] -- #{msg}\n"
+    end
+
+    def dump_param_desc(param_desc)
+      methods = param_desc.methods - param_desc.class.methods
+      for m in methods
+        print "#{m}\n"
+      end
+    end
+
+
+    # the @master_id is a number that is uniquely derived from the list of operations
+    # added to the swagger definition (in an order-dependent way).
+    # it is used for regression testing, allowing some differentiation between changes that
+    # result from changes to the input and those that result from changes to the generation
+    # algorithms.
+    # note that at the moment, this only takes operation ids into account, and ignores parameter
+    # definitions, so it's only partially useful.
+    def include_op_id_in_master_identifier(op_id)
+      @master_id = Zlib::crc32("#{@master_id} #{op_id}")
+    end
+
+
+    def save_and_compare
+      json = JSON.pretty_generate(@swagger)
+
+      newfile = File.expand_path("../tmp/out_#{@master_id}#{params_in_body? ? '_inbody':''}#{params_in_body_use_reference? ? '_ref':''}_new.json", __FILE__)
+      reffile = File.expand_path("../tmp/out_#{@master_id}#{params_in_body? ? '_inbody':''}#{params_in_body_use_reference? ? '_ref':''}_base.json", __FILE__)
+
+      File.open(newfile, "w") { |f| f.write(json)}
+      print "\n#{newfile}:1\n"
+
+      if !Pathname.new(reffile).exist?
+        print "Reference file does not exist.  Creating (#{reffile})"
+        File.open(reffile, "w") { |f| f.write(json)}
+      else
+        stdout, stderr, status = Open3.capture3("diff '#{newfile}' '#{reffile}'")
+        if status != 0
+          print "*** NEW FILE NOT IDENTICAL TO PREVIOUS VERSION (#{status}) ***\n"
+          print stderr, "\n"
+          print stdout
+        else
+          print("\nDiff result: files are identical\n")
+        end
+      end
+
+    end
+
+    #--------------------------------------------------------------------------
+    # Create a tag description for a described resource
+    #--------------------------------------------------------------------------
+
+    def tag_name_for_resource(resource)
+      # resource.controller
+      resource._id
+    end
+
+    def add_resource_description(resource_name, resource)
+      if resource._full_description
+        @tags << {
+            name: tag_name_for_resource(resource),
+            description: resource._full_description
+        }
+      end
+    end
+
+    #--------------------------------------------------------------------------
+    # Create swagger definitions for a ruby method
+    #--------------------------------------------------------------------------
+
+    def add_ruby_method(paths, ruby_method)
+
+      if @only_method
+        return unless ruby_method.name == @only_method
+      else
+        return if !ruby_method.show
+      end
+
+      for api in ruby_method.apis do
+        # controller: ruby_method.resource.controller.name,
+
+        path = swagger_path(api.path)
+        paths[path] ||= {}
+        methods = paths[path]
+        @current_method = ruby_method
+
+        @warnings_issued = false
+        responses = swagger_responses_hash_for_method(ruby_method)
+        if include_warning_tags?
+          warning_tags = @warnings_issued ? ['warnings issued'] : []
+        else
+          warning_tags = []
+        end
+
+        op_id = swagger_op_id_for_path(api.http_method, api.path)
+
+        include_op_id_in_master_identifier(op_id)
+
+        method_key = api.http_method.downcase
+        @current_http_method = method_key
+
+        methods[method_key] = {
+            tags: [tag_name_for_resource(ruby_method.resource)] + warning_tags,
+            operationId: op_id,
+            summary: Apipie.app.translate(api.short_description, @current_lang),
+            parameters: swagger_params_array_for_method(ruby_method, api.path),
+            responses: responses
+        }
+
+        if methods[method_key][:summary].nil?
+          methods[method_key].delete(:summary)
+          warn_missing_method_summary
+        end
+      end
+    end
+
+    #--------------------------------------------------------------------------
+    # Utilities for conversion of ruby syntax to swagger syntax
+    #--------------------------------------------------------------------------
+
+    def swagger_path(str)
+      str = str.gsub(/:(\w+)/, '{\1}')
+      str = str.gsub(/\/$/, '')
+
+      if str[0] != '/'
+        warn_added_missing_slash(str)
+        str = '/' + str
+      end
+      str
+    end
+
+    def remove_colons(str)
+      str.gsub(":", "_")
+    end
+
+    def swagger_op_id_for_method(method)
+      remove_colons method.resource.controller.name + "::" + method.method
+    end
+
+    def swagger_op_id_for_path(http_method, path)
+      http_method.upcase + path.gsub(/\//,'_').gsub(/:(\w+)/, '\1')
+    end
+
+    def swagger_param_type(param_desc)
+      if param_desc.nil?
+        raise("problem")
+      end
+
+      v = param_desc.validator
+      if v.nil?
+        return "string"
+      end
+
+      if v.class == Apipie::Validator::EnumValidator
+        if v.values - [true, false] == [] && [true, false] - v.values == []
+          # info("[#{param_desc.name}] is Enum with [true,false] values. Inferring 'boolean'.")
+          return "boolean"
+        else
+          return "enum"
+        end
+      elsif v.class == Apipie::Validator::HashValidator
+        # pp v
+      end
+
+      lookup = {
+          numeric: "number",
+          hash: "object",
+          array: "array"
+      }
+
+      investigate("validator class for [#{param_desc.name}]: #{v.class}")
+      return lookup[v.expected_type.to_sym] || v.expected_type
+    end
+
+
+    #--------------------------------------------------------------------------
+    # Responses
+    #--------------------------------------------------------------------------
+
+    def swagger_responses_hash_for_method(method)
+      result = {}
+
+      for error in method.errors
+        error_block = {description: Apipie.app.translate(error.description, @current_lang)}
+        result[error.code] = error_block
+      end
+
+      if result.length == 0
+        warn_no_return_codes_specified
+        result[200] = {description: 'ok'}
+      end
+
+      result
+    end
+
+
+
+    #--------------------------------------------------------------------------
+    # Auto-insertion of parameters that are implicitly defined in the path
+    #--------------------------------------------------------------------------
+
+    def param_names_from_path(path)
+      path.scan(/:(\w+)/).map do |ar|
+        ar[0].to_sym
+      end
+    end
+
+    def add_missing_params(method, path)
+      param_names_from_method = method.params.map {|name, desc| name}
+      missing = param_names_from_path(path) - param_names_from_method
+
+      result = method.params
+
+      missing.each do |name|
+        warn_path_parameter_not_described(name, path)
+        result[name.to_sym] = OpenStruct.new({
+                                                 required: true,
+                                                 _gen_added_from_path: true,
+                                                 name: name,
+                                                 validator: Apipie::Validator::NumberValidator.new(nil),
+                                                 options: {
+                                                     in: "path"
+                                                 }
+                                             })
+      end
+
+      result
+    end
+
+    #--------------------------------------------------------------------------
+    # The core routine for creating a swagger parameter definition block.
+    # The output is slightly different when the parameter is inside a schema block.
+    #--------------------------------------------------------------------------
+    def swagger_atomic_param(param_desc, in_schema, name=nil)
+      def save_field(entry, openapi_key, v, apipie_key=openapi_key, translate=false)
+        if v.key?(apipie_key)
+          if translate
+            entry[openapi_key] = Apipie.app.translate(v[apipie_key], @current_lang)
+          else
+            entry[openapi_key] = v[apipie_key]
+          end
+        end
+      end
+
+      swagger_def = {}
+      swagger_def[:name] = name if !name.nil?
+      swagger_def[:type] = swagger_param_type(param_desc)
+
+      if swagger_def[:type] == "array"
+        swagger_def[:items] = {type: "string"} # TODO: add support for arrays of non-string items
+      end
+
+      if swagger_def[:type] == "enum"
+        swagger_def[:type] = "string"
+        swagger_def[:enum] = param_desc.validator.values
+      end
+
+      if swagger_def[:type] == "object"  # we only get here if there is no specification of properties for this object
+        swagger_def[:additionalProperties] = true
+        warn_hash_without_internal_typespec(param_desc.name)
+      end
+
+      if !in_schema
+        swagger_def[:in] = param_desc.options.fetch(:in, @default_value_for_param_in)
+        swagger_def[:required] = param_desc.required if param_desc.required
+      end
+
+      save_field(swagger_def, :description, param_desc.options, :desc, true)
+      save_field(swagger_def, :default, param_desc.options, :default_value)
+
+      if param_desc.respond_to?(:_gen_added_from_path) && !param_desc.required
+        warn_optional_param_in_path(param_desc.name)
+        swagger_def[:required] = true
+      end
+
+      if !swagger_def[:required] && !swagger_def.key?(:default)
+        warn_optional_without_default_value(param_desc.name)
+      end
+
+      swagger_def
+    end
+
+
+    #--------------------------------------------------------------------------
+    # JSON schema and referenced-object generation
+    #--------------------------------------------------------------------------
+
+    def ref_to(name)
+      "#/definitions/#{name}"
+    end
+
+
+    def json_schema_obj_from_params_array(params_array)
+      (param_defs, required_params) = json_schema_param_defs_from_params_array(params_array)
+
+      result = {type: "object"}
+      result[:properties] = param_defs
+      result[:required] = required_params if required_params.length > 0
+
+      param_defs.length > 0 ? result : nil
+    end
+
+    def gen_referenced_block_from_params_array(name, params_array)
+      return ref_to(:name) if @definitions.key(:name)
+
+      schema_obj = json_schema_obj_from_params_array(params_array)
+      return nil if schema_obj.nil?
+
+      @definitions[name] = schema_obj
+      ref_to(name)
+    end
+
+    def json_schema_param_defs_from_params_array(params_array)
+      param_defs = {}
+      required_params = []
+
+      params_array ||= []
+
+
+      for param_desc in params_array
+        if !param_desc.respond_to?(:required)
+          # pp param_desc
+          raise ("unexpected param_desc format")
+        end
+
+        required_params.push(param_desc.name) if param_desc.required
+
+        param_type = swagger_param_type(param_desc)
+
+        if param_type == "object" && param_desc.validator.params_ordered
+          schema = json_schema_obj_from_params_array(param_desc.validator.params_ordered)
+          param_defs[param_desc.name] = schema if !schema.nil?
+        else
+          param_defs[param_desc.name] = swagger_atomic_param(param_desc, true)
+        end
+      end
+
+      [param_defs, required_params]
+    end
+
+
+
+    #--------------------------------------------------------------------------
+    # swagger "Params" block generation
+    #--------------------------------------------------------------------------
+
+    def body_allowed_for_current_method
+      !(['get', 'head'].include?(@current_http_method))
+    end
+
+    def swagger_params_array_for_method(method, path)
+
+      swagger_result = []
+      all_params_hash = add_missing_params(method, path)
+
+      body_param_defs_array = all_params_hash.map {|k, v| v if !param_names_from_path(path).include?(k)}.select{|v| !v.nil?}
+      body_param_defs_hash = all_params_hash.select {|k, v| v if !param_names_from_path(path).include?(k)}
+      path_param_defs_hash = all_params_hash.select {|k, v| v if param_names_from_path(path).include?(k)}
+
+      path_param_defs_hash.each{|name,desc| desc.required = true}
+      add_params_from_hash(swagger_result, path_param_defs_hash, nil, "path")
+
+      if params_in_body? && body_allowed_for_current_method
+        if params_in_body_use_reference?
+          swagger_schema_for_body = {"$ref": gen_referenced_block_from_params_array("#{swagger_op_id_for_method(method)}_input", body_param_defs_array)}
+        else
+          swagger_schema_for_body = json_schema_obj_from_params_array(body_param_defs_array)
+        end
+
+        swagger_body_param = {
+            name: 'body',
+            in: 'body',
+            schema: swagger_schema_for_body
+        }
+        swagger_result.push(swagger_body_param) if !swagger_schema_for_body.nil?
+
+      else
+        add_params_from_hash(swagger_result, body_param_defs_hash)
+      end
+
+      swagger_result
+    end
+
+
+    def add_params_from_hash(swagger_params_array, param_defs, prefix=nil, default_value_for_in=nil)
+
+      if default_value_for_in
+        @default_value_for_param_in = default_value_for_in
+      else
+        if body_allowed_for_current_method
+          @default_value_for_param_in = "formData"
+        else
+          @default_value_for_param_in = "query"
+        end
+      end
+
+
+      param_defs.each do |name, desc|
+
+        if !prefix.nil?
+          name = "#{prefix}[#{name}]"
+        end
+
+        if swagger_param_type(desc) == "object"
+          if desc.validator.params_ordered
+            params_hash = desc.validator.params_ordered.map {|desc| [desc.name, desc]}.to_h
+            add_params_from_hash(swagger_params_array, params_hash, name)
+          else
+            warn_param_ignored_in_form_data(desc.name)
+          end
+        else
+          param_entry = swagger_atomic_param(desc, false, name)
+          if param_entry[:required]
+            swagger_params_array.unshift(param_entry)
+          else
+            swagger_params_array.push(param_entry)
+          end
+
+        end
+      end
+    end
+    
+  end
+
+end

--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -167,6 +167,10 @@ module Apipie
         self.new(param_description, argument) if argument.is_a?(Array)
       end
 
+      def values
+        @array
+      end
+
       def description
         string = @array.map { |value| "<code>#{value}</code>" }.join(', ')
         "Must be one of: #{string}."

--- a/lib/tasks/apipie.rake
+++ b/lib/tasks/apipie.rake
@@ -52,19 +52,69 @@ namespace :apipie do
   end
 
   desc "Generate static swagger json"
-  task :static_swagger_json, [:version, :swagger_content_type_input] => :environment do |t, args|
+  task :static_swagger_json, [:version, :swagger_content_type_input, :filename_suffix] => :environment do |t, args|
     with_loaded_documentation do
-      args.with_defaults(:version => Apipie.configuration.default_version, :swagger_content_type_input => :form_data)
-      Apipie.configuration.swagger_content_type_input = args[:swagger_content_type_input].to_sym
       out = ENV["OUT"] || File.join(::Rails.root, Apipie.configuration.doc_path, 'apidoc')
-      count = 0
-      ([nil] + Apipie.configuration.languages).each do |lang|
-        doc = Apipie.to_swagger_json(args[:version], nil, nil, lang, count==0)
-        generate_swagger_json_page(out, doc, lang)
-        count+=1
-      end
+      generate_swagger_using_args(args, out)
     end
   end
+
+  # The following task compares the currently-generated swagger output to a reference copy generated
+  # by the previous execution of this task.
+  # if a difference is detected, the current output will be stored as a reference.
+  # reference files have the
+  # if more than 3 references are detected, the older ones will be purged
+  desc "Did swagger output change since the last execution of this task?"
+  task :did_swagger_change, [:version, :swagger_content_type_input, :filename_suffix] => :environment do |t, args|
+    with_loaded_documentation do
+      out = ENV["OUT_REF"] || File.join(::Rails.root, Apipie.configuration.doc_path, 'apidoc_ref')
+      paths = generate_swagger_using_args(args, out)
+      paths.each {|path|
+        existing_files_in_dir = Pathname(out).children(true)
+
+        make_reference = false
+
+        # reference filenames have the format <basename>.<counter>.swagger_ref
+        reference_files = existing_files_in_dir.select{|f|
+              f.extname == '.swagger_ref' &&
+              f.basename.sub_ext("").extname.delete('.').to_i > 0 &&
+              f.basename.sub_ext("").sub_ext("") == path.basename.sub_ext("")
+        }
+        if reference_files.empty?
+          print "Reference file does not exist for [#{path}]\n"
+          counter = 1
+          make_reference = true
+        else
+          reference_files.sort_by! {|f| f.ctime }
+          last_ref = reference_files[-1]
+          print "Comparing [#{path}] to reference file: [#{last_ref.basename}]: "
+          if !FileUtils.compare_file(path, last_ref)
+            print("\n ---> Differences detected\n")
+            counter = last_ref.sub_ext("").extname.delete('.').to_i + 1
+            make_reference = true
+          else
+            print("identical\n")
+          end
+        end
+
+        if make_reference
+          new_path = path.sub_ext(".#{counter}.swagger_ref")
+          print " ---> Keeping current output as [#{new_path}]\n"
+          path.rename(new_path)
+          reference_files << new_path
+        else
+          path.delete
+        end
+
+        num_refs_to_keep = 3
+        if reference_files.length > num_refs_to_keep
+          (reference_files - reference_files[-num_refs_to_keep..-1]).each{|f| f.delete}
+        end
+      }
+    end
+  end
+
+
 
   # By default the full cache is built.
   # It is possible to generate index resp. resources only with
@@ -139,6 +189,26 @@ namespace :apipie do
     end
   end
 
+  def generate_swagger_using_args(args, out)
+    args.with_defaults(:version => Apipie.configuration.default_version,
+                       :swagger_content_type_input => :form_data,
+                       :filename_suffix => nil)
+    Apipie.configuration.swagger_content_type_input = args[:swagger_content_type_input].to_sym
+    count = 0
+
+    sfx = args[:filename_suffix] || "_#{args[:swagger_content_type_input]}"
+
+    paths = []
+
+    ([nil] + Apipie.configuration.languages).each do |lang|
+      doc = Apipie.to_swagger_json(args[:version], nil, nil, lang, count==0)
+      paths << generate_swagger_json_page(out, doc, sfx, lang)
+      count+=1
+    end
+
+    paths
+  end
+
   def generate_json_page(file_base, doc, lang = nil)
     FileUtils.mkdir_p(file_base) unless File.exists?(file_base)
 
@@ -146,11 +216,13 @@ namespace :apipie do
     File.open("#{file_base}/#{filename}", 'w') { |file| file.write(JSON.pretty_generate(doc)) }
   end
 
-  def generate_swagger_json_page(file_base, doc, lang = nil)
+  def generate_swagger_json_page(file_base, doc, sfx="", lang = nil)
     FileUtils.mkdir_p(file_base) unless File.exists?(file_base)
 
-    filename = "schema_swagger#{lang_ext(lang)}.json"
-    File.open("#{file_base}/#{filename}", 'w') { |file| file.write(JSON.pretty_generate(doc)) }
+    path = Pathname.new("#{file_base}/schema_swagger#{sfx}#{lang_ext(lang)}.json")
+    File.open(path, 'w') { |file| file.write(JSON.pretty_generate(doc)) }
+
+    path
   end
 
   def generate_one_page(file_base, doc, lang = nil)

--- a/spec/controllers/apipies_controller_spec.rb
+++ b/spec/controllers/apipies_controller_spec.rb
@@ -149,7 +149,6 @@ describe Apipie::ApipiesController do
       get :index, :params => { :type => "swagger"}
 
       assert_response :success
-      print response.body
       expect(response.body).not_to match(/"swagger":"2.0"/)
     end
 
@@ -157,7 +156,6 @@ describe Apipie::ApipiesController do
       get :index, :params => { :format => "json"}
 
       assert_response :success
-      print response.body
       expect(response.body).not_to match(/"swagger":"2.0"/)
     end
   end

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -268,6 +268,11 @@ class UsersController < ApplicationController
     render :plain => 'This is very similar to create action'
   end
 
+  api :GET, '/users/by_department', 'show users from a specific department'
+  param :department, ["finance", "operations", "sales", "marketing", "HR"], required: false, default_value: "sales"
+  def get_by_department
+    render :plain => 'nothing to see here'
+  end
 
   api :GET, '/users/desc_from_file', 'desc from file'
   document 'users/desc_from_file.md'

--- a/spec/lib/rake_swagger_spec.rb
+++ b/spec/lib/rake_swagger_spec.rb
@@ -42,7 +42,7 @@ describe 'rake tasks' do
       params = apidoc_swagger["paths"][path][http_method]["parameters"]
       body = params.select {|p| p if p["name"]=="body"}[0]
       schema_properties = body["schema"]["properties"]
-      print JSON.pretty_generate(schema_properties)
+      # print JSON.pretty_generate(schema_properties)
       param = (schema_properties.select {|k,v| v if k == param_name })[param_name]
       # print JSON.pretty_generate(param)
       param

--- a/spec/lib/rake_swagger_spec.rb
+++ b/spec/lib/rake_swagger_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+describe 'rake tasks' do
+  include_context "rake"
+
+  let(:doc_path)  { "user_specified_doc_path" }
+
+  before do
+    Apipie.configuration.doc_path = doc_path
+    Apipie.configuration.swagger_suppress_warnings = true
+    allow(Apipie).to receive(:reload_documentation)
+    subject.invoke(*task_args)
+  end
+
+  describe 'static swagger specification files' do
+
+    let(:apidoc_swagger_json) do
+      File.read("#{doc_output}/schema_swagger.json")
+    end
+
+    let(:apidoc_swagger) do
+      JSON.parse(apidoc_swagger_json)
+    end
+
+    let(:doc_output) do
+      File.join(::Rails.root, doc_path, 'apidoc')
+    end
+
+    after do
+      # Dir["#{doc_output}*"].each { |static_file| FileUtils.rm_rf(static_file) }
+    end
+
+
+    def expect_param_def(http_method, path, param_name, field, value)
+      params = apidoc_swagger["paths"][path][http_method]["parameters"]
+      param = params.select {|p| p if p["name"]==param_name}[0]
+      expect(param[field]).to eq(value)
+    end
+
+
+    def body_param_def(http_method, path, param_name)
+      params = apidoc_swagger["paths"][path][http_method]["parameters"]
+      body = params.select {|p| p if p["name"]=="body"}[0]
+      schema_properties = body["schema"]["properties"]
+      print JSON.pretty_generate(schema_properties)
+      param = (schema_properties.select {|k,v| v if k == param_name })[param_name]
+      # print JSON.pretty_generate(param)
+      param
+    end
+
+    def expect_body_param_def(http_method, path, param_name, field, value)
+      param = body_param_def(http_method, path, param_name)
+      expect(param[field]).to eq(value)
+    end
+
+
+    describe 'apipie:static_swagger_json[development,json]' do
+      it "generates static swagger files for the default version of apipie docs" do
+        # print apidoc_swagger_json
+
+        expect(apidoc_swagger["info"]["title"]).to eq("Test app")
+        expect(apidoc_swagger["info"]["version"]).to eq("#{Apipie.configuration.default_version}")
+
+        expect_param_def("get", "/twitter_example/{id}", "screen_name", "in", "query")
+        expect_param_def("put", "/users/{id}", "id", "in", "path")
+        expect_body_param_def("put", "/users/{id}", "oauth", "type", "string")
+        expect_body_param_def("put", "/users/{id}", "user", "type", "object")
+
+        user = body_param_def("put", "/users/{id}", "user")
+        expect(user["properties"]["name"]["type"]).to eq("string")
+
+        expect_param_def("get", "/users/by_department", "department", "in", "query")
+        expect_param_def("get", "/users/by_department", "department", "enum",
+                         ["finance", "operations", "sales", "marketing", "HR"])
+
+      end
+    end
+
+    describe 'apipie:static_swagger_json[development,form_data]' do
+      it "generates static swagger files for the default version of apipie docs" do
+        # print apidoc_swagger_json
+
+        expect(apidoc_swagger["info"]["title"]).to eq("Test app")
+        expect(apidoc_swagger["info"]["version"]).to eq("#{Apipie.configuration.default_version}")
+
+        expect_param_def("get", "/twitter_example/{id}", "screen_name", "in", "query")
+        expect_param_def("put", "/users/{id}", "id", "in", "path")
+        expect_param_def("put", "/users/{id}", "oauth", "in", "formData")
+        expect_param_def("get", "/users/by_department", "department", "in", "query")
+        expect_param_def("get", "/users/by_department", "department", "enum",
+                         ["finance", "operations", "sales", "marketing", "HR"])
+
+      end
+    end
+
+  end
+
+end

--- a/spec/lib/rake_swagger_spec.rb
+++ b/spec/lib/rake_swagger_spec.rb
@@ -14,8 +14,13 @@ describe 'rake tasks' do
 
   describe 'static swagger specification files' do
 
+    after do
+      Dir["#{doc_output}*"].each { |static_file| FileUtils.rm_rf(static_file) }
+    end
+
     let(:apidoc_swagger_json) do
-      File.read("#{doc_output}/schema_swagger.json")
+      # note:  the filename ends with '_tmp' because this suffix is passed as a parameter to the rake task
+      File.read("#{doc_output}/schema_swagger_tmp.json")
     end
 
     let(:apidoc_swagger) do
@@ -26,8 +31,8 @@ describe 'rake tasks' do
       File.join(::Rails.root, doc_path, 'apidoc')
     end
 
-    after do
-      # Dir["#{doc_output}*"].each { |static_file| FileUtils.rm_rf(static_file) }
+    let(:ref_output) do
+      File.join(::Rails.root, doc_path, 'apidoc_ref')
     end
 
 
@@ -54,11 +59,11 @@ describe 'rake tasks' do
     end
 
 
-    describe 'apipie:static_swagger_json[development,json]' do
+    describe 'apipie:static_swagger_json[development,json,_tmp]' do
       it "generates static swagger files for the default version of apipie docs" do
         # print apidoc_swagger_json
 
-        expect(apidoc_swagger["info"]["title"]).to eq("Test app")
+        expect(apidoc_swagger["info"]["title"]).to eq("Test app (params in:body)")
         expect(apidoc_swagger["info"]["version"]).to eq("#{Apipie.configuration.default_version}")
 
         expect_param_def("get", "/twitter_example/{id}", "screen_name", "in", "query")
@@ -76,11 +81,11 @@ describe 'rake tasks' do
       end
     end
 
-    describe 'apipie:static_swagger_json[development,form_data]' do
+    describe 'apipie:static_swagger_json[development,form_data,_tmp]' do
       it "generates static swagger files for the default version of apipie docs" do
         # print apidoc_swagger_json
 
-        expect(apidoc_swagger["info"]["title"]).to eq("Test app")
+        expect(apidoc_swagger["info"]["title"]).to eq("Test app (params in:formData)")
         expect(apidoc_swagger["info"]["version"]).to eq("#{Apipie.configuration.default_version}")
 
         expect_param_def("get", "/twitter_example/{id}", "screen_name", "in", "query")
@@ -93,6 +98,11 @@ describe 'rake tasks' do
       end
     end
 
+    describe 'apipie:did_swagger_change[development,form_data,_tmp]' do
+      it "keeps a reference file" do
+        expect(Pathname(ref_output).children.count).to eq(2)  # one file for each language
+      end
+    end
   end
 
 end

--- a/spec/lib/swagger/openapi_2_0_schema.json
+++ b/spec/lib/swagger/openapi_2_0_schema.json
@@ -1,0 +1,1607 @@
+{
+  "title": "A JSON Schema for Swagger 2.0 API.",
+  "id": "http://swagger.io/v2/schema.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "swagger",
+    "info",
+    "paths"
+  ],
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-": {
+      "$ref": "#/definitions/vendorExtension"
+    }
+  },
+  "properties": {
+    "swagger": {
+      "type": "string",
+      "enum": [
+        "2.0"
+      ],
+      "description": "The Swagger version of this document."
+    },
+    "info": {
+      "$ref": "#/definitions/info"
+    },
+    "host": {
+      "type": "string",
+      "pattern": "^[^{}/ :\\\\]+(?::\\d+)?$",
+      "description": "The host (name or ip) of the API. Example: 'swagger.io'"
+    },
+    "basePath": {
+      "type": "string",
+      "pattern": "^/",
+      "description": "The base path to the API. Example: '/api'."
+    },
+    "schemes": {
+      "$ref": "#/definitions/schemesList"
+    },
+    "consumes": {
+      "description": "A list of MIME types accepted by the API.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/mediaTypeList"
+        }
+      ]
+    },
+    "produces": {
+      "description": "A list of MIME types the API can produce.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/mediaTypeList"
+        }
+      ]
+    },
+    "paths": {
+      "$ref": "#/definitions/paths"
+    },
+    "definitions": {
+      "$ref": "#/definitions/definitions"
+    },
+    "parameters": {
+      "$ref": "#/definitions/parameterDefinitions"
+    },
+    "responses": {
+      "$ref": "#/definitions/responseDefinitions"
+    },
+    "security": {
+      "$ref": "#/definitions/security"
+    },
+    "securityDefinitions": {
+      "$ref": "#/definitions/securityDefinitions"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/tag"
+      },
+      "uniqueItems": true
+    },
+    "externalDocs": {
+      "$ref": "#/definitions/externalDocs"
+    }
+  },
+  "definitions": {
+    "info": {
+      "type": "object",
+      "description": "General information about the API.",
+      "required": [
+        "version",
+        "title"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "A unique and precise title of the API."
+        },
+        "version": {
+          "type": "string",
+          "description": "A semantic version number of the API."
+        },
+        "description": {
+          "type": "string",
+          "description": "A longer description of the API. Should be different from the title.  GitHub Flavored Markdown is allowed."
+        },
+        "termsOfService": {
+          "type": "string",
+          "description": "The terms of service for the API."
+        },
+        "contact": {
+          "$ref": "#/definitions/contact"
+        },
+        "license": {
+          "$ref": "#/definitions/license"
+        }
+      }
+    },
+    "contact": {
+      "type": "object",
+      "description": "Contact information for the owners of the API.",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The identifying name of the contact person/organization."
+        },
+        "url": {
+          "type": "string",
+          "description": "The URL pointing to the contact information.",
+          "format": "uri"
+        },
+        "email": {
+          "type": "string",
+          "description": "The email address of the contact person/organization.",
+          "format": "email"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "license": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the license type. It's encouraged to use an OSI compatible license."
+        },
+        "url": {
+          "type": "string",
+          "description": "The URL pointing to the license.",
+          "format": "uri"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "paths": {
+      "type": "object",
+      "description": "Relative paths to the individual endpoints. They must be relative to the 'basePath'.",
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        },
+        "^/": {
+          "$ref": "#/definitions/pathItem"
+        }
+      },
+      "additionalProperties": false
+    },
+    "definitions": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/schema"
+      },
+      "description": "One or more JSON objects describing the schemas being consumed and produced by the API."
+    },
+    "parameterDefinitions": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/parameter"
+      },
+      "description": "One or more JSON representations for parameters"
+    },
+    "responseDefinitions": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/response"
+      },
+      "description": "One or more JSON representations for responses"
+    },
+    "externalDocs": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "information about external documentation",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "examples": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "mimeType": {
+      "type": "string",
+      "description": "The MIME type of the HTTP message."
+    },
+    "operation": {
+      "type": "object",
+      "required": [
+        "responses"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "summary": {
+          "type": "string",
+          "description": "A brief summary of the operation."
+        },
+        "description": {
+          "type": "string",
+          "description": "A longer description of the operation, GitHub Flavored Markdown is allowed."
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        },
+        "operationId": {
+          "type": "string",
+          "description": "A unique identifier of the operation."
+        },
+        "produces": {
+          "description": "A list of MIME types the API can produce.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/mediaTypeList"
+            }
+          ]
+        },
+        "consumes": {
+          "description": "A list of MIME types the API can consume.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/mediaTypeList"
+            }
+          ]
+        },
+        "parameters": {
+          "$ref": "#/definitions/parametersList"
+        },
+        "responses": {
+          "$ref": "#/definitions/responses"
+        },
+        "schemes": {
+          "$ref": "#/definitions/schemesList"
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "security": {
+          "$ref": "#/definitions/security"
+        }
+      }
+    },
+    "pathItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "$ref": {
+          "type": "string"
+        },
+        "get": {
+          "$ref": "#/definitions/operation"
+        },
+        "put": {
+          "$ref": "#/definitions/operation"
+        },
+        "post": {
+          "$ref": "#/definitions/operation"
+        },
+        "delete": {
+          "$ref": "#/definitions/operation"
+        },
+        "options": {
+          "$ref": "#/definitions/operation"
+        },
+        "head": {
+          "$ref": "#/definitions/operation"
+        },
+        "patch": {
+          "$ref": "#/definitions/operation"
+        },
+        "parameters": {
+          "$ref": "#/definitions/parametersList"
+        }
+      }
+    },
+    "responses": {
+      "type": "object",
+      "description": "Response objects names can either be any valid HTTP status code or 'default'.",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "patternProperties": {
+        "^([0-9]{3})$|^(default)$": {
+          "$ref": "#/definitions/responseValue"
+        },
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "not": {
+        "type": "object",
+        "additionalProperties": false,
+        "patternProperties": {
+          "^x-": {
+            "$ref": "#/definitions/vendorExtension"
+          }
+        }
+      }
+    },
+    "responseValue": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/response"
+        },
+        {
+          "$ref": "#/definitions/jsonReference"
+        }
+      ]
+    },
+    "response": {
+      "type": "object",
+      "required": [
+        "description"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/schema"
+            },
+            {
+              "$ref": "#/definitions/fileSchema"
+            }
+          ]
+        },
+        "headers": {
+          "$ref": "#/definitions/headers"
+        },
+        "examples": {
+          "$ref": "#/definitions/examples"
+        }
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "headers": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/header"
+      }
+    },
+    "header": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "array"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormat"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "vendorExtension": {
+      "description": "Any property starting with x- is valid.",
+      "additionalProperties": true,
+      "additionalItems": true
+    },
+    "bodyParameter": {
+      "type": "object",
+      "required": [
+        "name",
+        "in",
+        "schema"
+      ],
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the parameter."
+        },
+        "in": {
+          "type": "string",
+          "description": "Determines the location of the parameter.",
+          "enum": [
+            "body"
+          ]
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Determines whether or not this parameter is required or optional.",
+          "default": false
+        },
+        "schema": {
+          "$ref": "#/definitions/schema"
+        }
+      },
+      "additionalProperties": false
+    },
+    "headerParameterSubSchema": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "description": "Determines whether or not this parameter is required or optional.",
+          "default": false
+        },
+        "in": {
+          "type": "string",
+          "description": "Determines the location of the parameter.",
+          "enum": [
+            "header"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the parameter."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "integer",
+            "array"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormat"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        }
+      }
+    },
+    "queryParameterSubSchema": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "description": "Determines whether or not this parameter is required or optional.",
+          "default": false
+        },
+        "in": {
+          "type": "string",
+          "description": "Determines the location of the parameter.",
+          "enum": [
+            "query"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the parameter."
+        },
+        "allowEmptyValue": {
+          "type": "boolean",
+          "default": false,
+          "description": "allows sending a parameter by name only or with an empty value."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "integer",
+            "array"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormatWithMulti"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        }
+      }
+    },
+    "formDataParameterSubSchema": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "description": "Determines whether or not this parameter is required or optional.",
+          "default": false
+        },
+        "in": {
+          "type": "string",
+          "description": "Determines the location of the parameter.",
+          "enum": [
+            "formData"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the parameter."
+        },
+        "allowEmptyValue": {
+          "type": "boolean",
+          "default": false,
+          "description": "allows sending a parameter by name only or with an empty value."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "integer",
+            "array",
+            "file"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormatWithMulti"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        }
+      }
+    },
+    "pathParameterSubSchema": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "required": [
+        "required"
+      ],
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "enum": [
+            true
+          ],
+          "description": "Determines whether or not this parameter is required or optional."
+        },
+        "in": {
+          "type": "string",
+          "description": "Determines the location of the parameter.",
+          "enum": [
+            "path"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the parameter."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "integer",
+            "array"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormat"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        }
+      }
+    },
+    "nonBodyParameter": {
+      "type": "object",
+      "required": [
+        "name",
+        "in",
+        "type"
+      ],
+      "oneOf": [
+        {
+          "$ref": "#/definitions/headerParameterSubSchema"
+        },
+        {
+          "$ref": "#/definitions/formDataParameterSubSchema"
+        },
+        {
+          "$ref": "#/definitions/queryParameterSubSchema"
+        },
+        {
+          "$ref": "#/definitions/pathParameterSubSchema"
+        }
+      ]
+    },
+    "parameter": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/bodyParameter"
+        },
+        {
+          "$ref": "#/definitions/nonBodyParameter"
+        }
+      ]
+    },
+    "schema": {
+      "type": "object",
+      "description": "A deterministic version of a JSON Schema object.",
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "$ref": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "title": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+        },
+        "description": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
+        },
+        "default": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
+        },
+        "multipleOf": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
+        },
+        "maximum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+        },
+        "minLength": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+        },
+        "pattern": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
+        },
+        "maxItems": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+        },
+        "minItems": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+        },
+        "uniqueItems": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
+        },
+        "maxProperties": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+        },
+        "minProperties": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+        },
+        "required": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
+        },
+        "enum": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
+        },
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/schema"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "default": {}
+        },
+        "type": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/type"
+        },
+        "items": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/schema"
+            },
+            {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/schema"
+              }
+            }
+          ],
+          "default": {}
+        },
+        "allOf": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/schema"
+          }
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/schema"
+          },
+          "default": {}
+        },
+        "discriminator": {
+          "type": "string"
+        },
+        "readOnly": {
+          "type": "boolean",
+          "default": false
+        },
+        "xml": {
+          "$ref": "#/definitions/xml"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        },
+        "example": {}
+      },
+      "additionalProperties": false
+    },
+    "fileSchema": {
+      "type": "object",
+      "description": "A deterministic version of a JSON Schema object.",
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "format": {
+          "type": "string"
+        },
+        "title": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+        },
+        "description": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
+        },
+        "default": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
+        },
+        "required": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "file"
+          ]
+        },
+        "readOnly": {
+          "type": "boolean",
+          "default": false
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        },
+        "example": {}
+      },
+      "additionalProperties": false
+    },
+    "primitivesItems": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "array"
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/primitivesItems"
+        },
+        "collectionFormat": {
+          "$ref": "#/definitions/collectionFormat"
+        },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusiveMaximum"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusiveMinimum"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/maxLength"
+        },
+        "minLength": {
+          "$ref": "#/definitions/minLength"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/maxItems"
+        },
+        "minItems": {
+          "$ref": "#/definitions/minItems"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/uniqueItems"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multipleOf"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "security": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/securityRequirement"
+      },
+      "uniqueItems": true
+    },
+    "securityRequirement": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "uniqueItems": true
+      }
+    },
+    "xml": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "attribute": {
+          "type": "boolean",
+          "default": false
+        },
+        "wrapped": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "tag": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "securityDefinitions": {
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/basicAuthenticationSecurity"
+          },
+          {
+            "$ref": "#/definitions/apiKeySecurity"
+          },
+          {
+            "$ref": "#/definitions/oauth2ImplicitSecurity"
+          },
+          {
+            "$ref": "#/definitions/oauth2PasswordSecurity"
+          },
+          {
+            "$ref": "#/definitions/oauth2ApplicationSecurity"
+          },
+          {
+            "$ref": "#/definitions/oauth2AccessCodeSecurity"
+          }
+        ]
+      }
+    },
+    "basicAuthenticationSecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "basic"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "apiKeySecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "name",
+        "in"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "apiKey"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "type": "string",
+          "enum": [
+            "header",
+            "query"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "oauth2ImplicitSecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "flow",
+        "authorizationUrl"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "oauth2"
+          ]
+        },
+        "flow": {
+          "type": "string",
+          "enum": [
+            "implicit"
+          ]
+        },
+        "scopes": {
+          "$ref": "#/definitions/oauth2Scopes"
+        },
+        "authorizationUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "oauth2PasswordSecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "flow",
+        "tokenUrl"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "oauth2"
+          ]
+        },
+        "flow": {
+          "type": "string",
+          "enum": [
+            "password"
+          ]
+        },
+        "scopes": {
+          "$ref": "#/definitions/oauth2Scopes"
+        },
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "oauth2ApplicationSecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "flow",
+        "tokenUrl"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "oauth2"
+          ]
+        },
+        "flow": {
+          "type": "string",
+          "enum": [
+            "application"
+          ]
+        },
+        "scopes": {
+          "$ref": "#/definitions/oauth2Scopes"
+        },
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "oauth2AccessCodeSecurity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "flow",
+        "authorizationUrl",
+        "tokenUrl"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "oauth2"
+          ]
+        },
+        "flow": {
+          "type": "string",
+          "enum": [
+            "accessCode"
+          ]
+        },
+        "scopes": {
+          "$ref": "#/definitions/oauth2Scopes"
+        },
+        "authorizationUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "oauth2Scopes": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "mediaTypeList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/mimeType"
+      },
+      "uniqueItems": true
+    },
+    "parametersList": {
+      "type": "array",
+      "description": "The parameters needed to send a valid API call.",
+      "additionalItems": false,
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/parameter"
+          },
+          {
+            "$ref": "#/definitions/jsonReference"
+          }
+        ]
+      },
+      "uniqueItems": true
+    },
+    "schemesList": {
+      "type": "array",
+      "description": "The transfer protocol of the API.",
+      "items": {
+        "type": "string",
+        "enum": [
+          "http",
+          "https",
+          "ws",
+          "wss"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "collectionFormat": {
+      "type": "string",
+      "enum": [
+        "csv",
+        "ssv",
+        "tsv",
+        "pipes"
+      ],
+      "default": "csv"
+    },
+    "collectionFormatWithMulti": {
+      "type": "string",
+      "enum": [
+        "csv",
+        "ssv",
+        "tsv",
+        "pipes",
+        "multi"
+      ],
+      "default": "csv"
+    },
+    "title": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+    },
+    "description": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
+    },
+    "default": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
+    },
+    "multipleOf": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
+    },
+    "maximum": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
+    },
+    "exclusiveMaximum": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+    },
+    "minimum": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
+    },
+    "exclusiveMinimum": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+    },
+    "maxLength": {
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+    },
+    "minLength": {
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+    },
+    "pattern": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
+    },
+    "maxItems": {
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+    },
+    "minItems": {
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+    },
+    "uniqueItems": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
+    },
+    "enum": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
+    },
+    "jsonReference": {
+      "type": "object",
+      "required": [
+        "$ref"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "$ref": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/spec/lib/swagger/rake_swagger_spec.rb
+++ b/spec/lib/swagger/rake_swagger_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require "json-schema"
 
 describe 'rake tasks' do
   include_context "rake"
@@ -16,6 +17,10 @@ describe 'rake tasks' do
 
     after do
       Dir["#{doc_output}*"].each { |static_file| FileUtils.rm_rf(static_file) }
+    end
+
+    let(:swagger_schema) do
+      File.read(File.join(File.dirname(__FILE__),"openapi_2_0_schema.json"))
     end
 
     let(:apidoc_swagger_json) do
@@ -65,7 +70,9 @@ describe 'rake tasks' do
 
         expect(apidoc_swagger["info"]["title"]).to eq("Test app (params in:body)")
         expect(apidoc_swagger["info"]["version"]).to eq("#{Apipie.configuration.default_version}")
+      end
 
+      it "includes expected values in the generated swagger file" do
         expect_param_def("get", "/twitter_example/{id}", "screen_name", "in", "query")
         expect_param_def("put", "/users/{id}", "id", "in", "path")
         expect_body_param_def("put", "/users/{id}", "oauth", "type", "string")
@@ -77,7 +84,11 @@ describe 'rake tasks' do
         expect_param_def("get", "/users/by_department", "department", "in", "query")
         expect_param_def("get", "/users/by_department", "department", "enum",
                          ["finance", "operations", "sales", "marketing", "HR"])
+      end
 
+      it "generates a valid swagger file" do
+        # print apidoc_swagger_json
+        expect(JSON::Validator.validate(swagger_schema, apidoc_swagger_json)).to be_truthy
       end
     end
 
@@ -88,6 +99,9 @@ describe 'rake tasks' do
         expect(apidoc_swagger["info"]["title"]).to eq("Test app (params in:formData)")
         expect(apidoc_swagger["info"]["version"]).to eq("#{Apipie.configuration.default_version}")
 
+      end
+
+      it "includes expected values in the generated swagger file" do
         expect_param_def("get", "/twitter_example/{id}", "screen_name", "in", "query")
         expect_param_def("put", "/users/{id}", "id", "in", "path")
         expect_param_def("put", "/users/{id}", "oauth", "in", "formData")
@@ -95,6 +109,11 @@ describe 'rake tasks' do
         expect_param_def("get", "/users/by_department", "department", "enum",
                          ["finance", "operations", "sales", "marketing", "HR"])
 
+      end
+
+      it "generates a valid swagger file" do
+        # print apidoc_swagger_json
+        expect(JSON::Validator.validate(swagger_schema, apidoc_swagger_json)).to be_truthy
       end
     end
 


### PR DESCRIPTION
Hi,

I've added the capability to auto-generate static [Swagger](https://swagger.io/) definition files from the Apipie DSL.

The resulting Swagger ([OpenAPI 2.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md)) compliant JSON file can then be used to auto-generate REST clients, imported into tools like Postman, and so forth.

Swagger generation is implemented by crawling through Apipie's resource_descriptions construct.

The DSL is slightly enhanced to allow indication of default values of optional parameters.

There are a few configuration options that can be used to change the overall structure of the generated swagger file, in order to support both in:formData and in:body REST request styles.

Looking forward to hear your thoughts.