### PR TITLE
Prevent missing translation span in title

### DIFF
--- a/app/views/layouts/apipie/apipie.html.erb
+++ b/app/views/layouts/apipie/apipie.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title><%= t('apipie.api_documentation') %></title>
+  <title><%= t('apipie.api_documentation', :default => 'Api Documentation') %></title>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <%= Apipie.include_stylesheets %>


### PR DESCRIPTION
When the translation is missing it is wrapped with
<span class="translation_missing"... by rails. HTML elements
are not allowed within the title tag.