### PR TITLE
Replaced String#constantize with String#safe_constantize so apipie won't break on a missing constant

### DIFF
--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -56,8 +56,7 @@ module Apipie
     def route_app_controller(app, route, visited_apps = [])
       if route.defaults[:controller]
         controller_name = (route.defaults[:controller] + 'Controller').camelize
-        return unless Object.const_defined?(controller_name)
-        controller_name.constantize
+        controller_name.safe_constantize
       end
     end
 

--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -55,7 +55,9 @@ module Apipie
     # this method does in depth search for the route controller
     def route_app_controller(app, route, visited_apps = [])
       if route.defaults[:controller]
-        (route.defaults[:controller].camelize + "Controller").constantize
+        controller_name = (route.defaults[:controller] + 'Controller').camelize
+        return unless Object.const_defined?(controller_name)
+        controller_name.constantize
       end
     end
 

--- a/lib/apipie/extractor.rb
+++ b/lib/apipie/extractor.rb
@@ -154,8 +154,7 @@ module Apipie
       def update_api_descriptions
         apis_from_docs = all_apis_from_docs
         @apis_from_routes.each do |(controller, action), new_apis|
-          next unless Object.const_defined?(controller.camelize)
-          method_key = "#{Apipie.get_resource_name(controller.constantize)}##{action}"
+          method_key = "#{Apipie.get_resource_name(controller.safe_constantize || next)}##{action}"
           old_apis = apis_from_docs[method_key] || []
           new_apis.each do |new_api|
             new_api[:path].sub!(/\(\.:format\)$/,"") if new_api[:path]

--- a/lib/apipie/extractor.rb
+++ b/lib/apipie/extractor.rb
@@ -154,6 +154,7 @@ module Apipie
       def update_api_descriptions
         apis_from_docs = all_apis_from_docs
         @apis_from_routes.each do |(controller, action), new_apis|
+          next unless Object.const_defined?(controller.camelize)
           method_key = "#{Apipie.get_resource_name(controller.constantize)}##{action}"
           old_apis = apis_from_docs[method_key] || []
           new_apis.each do |new_api|

--- a/lib/tasks/apipie.rake
+++ b/lib/tasks/apipie.rake
@@ -225,8 +225,7 @@ MESSAGE
       apis_from_routes.each do |(controller, action), apis|
         next if ignored.include?(controller)
         next if ignored.include?("#{controller}##{action}")
-        next unless Object.const_defined?(controller.camelize)
-        Apipie::Extractor::Writer.update_action_description(controller.constantize, action) do |u|
+        Apipie::Extractor::Writer.update_action_description((controller.safe_constantize || next), action) do |u|
           u.update_apis(apis)
         end
       end

--- a/lib/tasks/apipie.rake
+++ b/lib/tasks/apipie.rake
@@ -225,6 +225,7 @@ MESSAGE
       apis_from_routes.each do |(controller, action), apis|
         next if ignored.include?(controller)
         next if ignored.include?("#{controller}##{action}")
+        next unless Object.const_defined?(controller.camelize)
         Apipie::Extractor::Writer.update_action_description(controller.constantize, action) do |u|
           u.update_apis(apis)
         end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -12,6 +12,11 @@ Dummy::Application.routes.draw do
       namespace :files do
         get '/*file_path', format: false, :action => 'download'
       end
+
+      # This is not directly used in the specs.
+      # It is only there to tests apipies tolerance regarding
+      # missing controllers.
+      resources :dangeling_stuff
       resources :twitter_example do
         collection do
           get :lookup


### PR DESCRIPTION
As mentioned in #551 apipie has a tendency to break if there are routes pointing to missing controllers.
This PR makes apipie skip these routes, thereby ignoring the missing controllers.