### PR TITLE
Inheritable param groups

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -334,7 +334,7 @@ params for ``create`` and ``update`` actions are shared between them.
 These params can be extracted with ``def_param_group`` and
 ``param_group`` keywords.
 
-The definition is looked up in the scope of the controller. If the
+The definition is looked up in the scope of the controller and its subclasses. If the
 group is defined in a different controller, it might be referenced by
 specifying the second argument.
 

--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -143,6 +143,8 @@ module Apipie
       key = "#{controller.name}##{name}"
       if @param_groups.has_key?(key)
         return @param_groups[key]
+      elsif controller.superclass != Object
+        get_param_group(controller.superclass, name)
       else
         raise "param group #{key} not defined"
       end

--- a/spec/dummy/app/controllers/api/v1/architectures_controller.rb
+++ b/spec/dummy/app/controllers/api/v1/architectures_controller.rb
@@ -8,7 +8,12 @@ module Api
       end
 
       api :GET, "/architectures/:id/", "Show an architecture."
+      param_group :identifier
       def show
+      end
+
+      def_param_group :identifier do
+        param :identifier, Hash, 'A hex based string to identify the resource.'
       end
 
       def_param_group :timestamps do

--- a/spec/dummy/app/controllers/api/v1/architectures_controller.rb
+++ b/spec/dummy/app/controllers/api/v1/architectures_controller.rb
@@ -3,6 +3,7 @@ module Api
     class ArchitecturesController < V1::BaseController
       resource_description { name 'Architectures' }
       api :GET, "/architectures/", "List all architectures."
+      param_group :pagination
       def index
       end
 

--- a/spec/dummy/app/controllers/api/v1/base_controller.rb
+++ b/spec/dummy/app/controllers/api/v1/base_controller.rb
@@ -6,6 +6,11 @@ module Api
         app_info 'Version 1.0 description'
         api_base_url '/api/v1'
       end
+
+      def_param_group :pagination do
+        param :page, Integer, 'The page of the resource.'
+        param :items_per_page, Integer, 'The number of items per page.'
+      end
     end
   end
 end

--- a/spec/dummy/app/controllers/api/v1/base_controller.rb
+++ b/spec/dummy/app/controllers/api/v1/base_controller.rb
@@ -11,6 +11,10 @@ module Api
         param :page, Integer, 'The page of the resource.'
         param :items_per_page, Integer, 'The number of items per page.'
       end
+
+      def_param_group :identifier do
+        param :identifier, Integer, 'The identifier of the resource.'
+      end
     end
   end
 end

--- a/spec/lib/param_group_spec.rb
+++ b/spec/lib/param_group_spec.rb
@@ -61,5 +61,7 @@ describe "param groups" do
     expect(Apipie['1.0#architectures#index'].params.key?(:items_per_page))
       .to be true
   end
+
+  it 'should be able to override inherited param_groups'
 end
 

--- a/spec/lib/param_group_spec.rb
+++ b/spec/lib/param_group_spec.rb
@@ -51,10 +51,9 @@ describe "param groups" do
     expect(Apipie["overridden_concern_resources#create"].params.has_key?(:user)).to eq(false)
   end
 
-it "shouldn't replace name of a parameter defined in the controller" do
+  it "shouldn't replace name of a parameter defined in the controller" do
     expect(Apipie["overridden_concern_resources#custom"].params.has_key?(:concern)).to eq(true)
     expect(Apipie["overridden_concern_resources#custom"].params.has_key?(:user)).to eq(false)
   end
-
 end
 

--- a/spec/lib/param_group_spec.rb
+++ b/spec/lib/param_group_spec.rb
@@ -62,6 +62,8 @@ describe "param groups" do
       .to be true
   end
 
-  it 'should be able to override inherited param_groups'
+  it 'should be able to override inherited param_groups' do
+    expect(Apipie['1.0#architectures#show'].params[:identifier].validator.expected_type).to eq 'hash'
+  end
 end
 

--- a/spec/lib/param_group_spec.rb
+++ b/spec/lib/param_group_spec.rb
@@ -55,5 +55,11 @@ describe "param groups" do
     expect(Apipie["overridden_concern_resources#custom"].params.has_key?(:concern)).to eq(true)
     expect(Apipie["overridden_concern_resources#custom"].params.has_key?(:user)).to eq(false)
   end
+
+  it 'should allow controllers to inherit param groups from their parents' do
+    expect(Apipie['1.0#architectures#index'].params.key?(:page)).to be true
+    expect(Apipie['1.0#architectures#index'].params.key?(:items_per_page))
+      .to be true
+  end
 end
 


### PR DESCRIPTION
This PR makes `param_group`s inheritable between Controllers.
Since the same functionality can already be achieved using the second argument to `param_group` this is more of a convenience feature.

Since `def_param_group` reminded me of `define_method` or just `def` i initially just assumed you would be able to inherit them. This should not break anything in the API since subclasses override the `param_group`s of their parents.