### PR TITLE
Enable tests for ruby 2.4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.0.0
   - 2.1.7
   - 2.2.3
   - 2.3.3
+  - 2.4.3
+  - 2.5.0
 gemfile:
   - Gemfile.rails41
   - Gemfile.rails42
@@ -20,3 +21,7 @@ matrix:
       gemfile: Gemfile.rails50
     - rvm: 2.1.7
       gemfile: Gemfile.rails51
+    - rvm: 2.4.3
+      gemfile: Gemfile.rails41
+    - rvm: 2.5.0
+      gemfile: Gemfile.rails41


### PR DESCRIPTION
Also, remove ruby 2.0 as that's already pretty old release.

Fixes #587