### PR TITLE
Gzip examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -550,6 +550,9 @@ app_name
 copyright
   Copyright information (shown in page footer).
 
+compress_examples
+  If ``true`` recorded examples are compressed using ``Zlib``. Useful for big test-suits.
+
 doc_base_url
   Documentation frontend base url.
 

--- a/lib/apipie/configuration.rb
+++ b/lib/apipie/configuration.rb
@@ -1,7 +1,8 @@
 module Apipie
   class Configuration
 
-    attr_accessor :app_name, :app_info, :copyright, :markup, :disqus_shortname,
+    attr_accessor :app_name, :app_info, :copyright, :compress_examples,
+      :markup, :disqus_shortname,
       :api_base_url, :doc_base_url, :required_by_default, :layout,
       :default_version, :debug, :version_in_url, :namespaced_resources,
       :validate, :validate_value, :validate_presence, :validate_key, :authenticate, :doc_path,

--- a/lib/apipie/extractor/writer.rb
+++ b/lib/apipie/extractor/writer.rb
@@ -3,9 +3,11 @@ require 'set'
 module Apipie
   module Extractor
     class Writer
+      attr_reader :compressed
 
       def initialize(collector)
         @collector = collector
+        @compressed = Apipie.configuration.compress_examples
       end
 
       def write_examples
@@ -53,7 +55,12 @@ module Apipie
       end
 
       def self.examples_file
-        File.join(Rails.root,Apipie.configuration.doc_path,"apipie_examples.json")
+        pure_path = Rails.root.join(
+          Apipie.configuration.doc_path, 'apipie_examples.json'
+        )
+        zipped_path = pure_path + '.gz'
+        return zipped_path if compressed && File.exist?(zipped_path)
+        pure_path
       end
 
       protected

--- a/lib/apipie/extractor/writer.rb
+++ b/lib/apipie/extractor/writer.rb
@@ -3,12 +3,75 @@ require 'set'
 module Apipie
   module Extractor
     class Writer
-      attr_reader :compressed
+      class << self
+        def compressed
+          Apipie.configuration.compress_examples
+        end
+
+        def update_action_description(controller, action)
+          updater = ActionDescriptionUpdater.new(controller, action)
+          yield updater
+          updater.write!
+        rescue ActionDescriptionUpdater::ControllerNotFound
+          logger.warn("REST_API: Couldn't find controller file for #{controller}")
+        rescue ActionDescriptionUpdater::ActionNotFound
+          logger.warn("REST_API: Couldn't find action #{action} in #{controller}")
+        end
+
+        def write_recorded_examples(examples)
+          FileUtils.mkdir_p(File.dirname(examples_file))
+          content = serialize_examples(examples)
+          content = Zlib::Deflate.deflate(content).force_encoding('utf-8') if compressed
+          File.open(examples_file, 'w') { |f| f << content }
+        end
+
+        def load_recorded_examples
+          return {} unless File.exist?(examples_file)
+          load_json_examples
+        end
+
+        def examples_file
+          pure_path = Rails.root.join(
+            Apipie.configuration.doc_path, 'apipie_examples.json'
+          )
+          zipped_path = pure_path.to_s + '.gz'
+          return zipped_path if compressed
+          pure_path.to_s
+        end
+
+        protected
+
+        def serialize_examples(examples)
+          JSON.pretty_generate(
+            OrderedHash[*examples.sort_by(&:first).flatten(1)]
+          )
+        end
+
+        def deserialize_examples(examples_string)
+          examples = JSON.parse(examples_string)
+          return {} if examples.nil?
+          examples.each_value do |records|
+            records.each do |record|
+              record['verb'] = record['verb'].to_sym if record['verb']
+            end
+          end
+        end
+
+        def load_json_examples
+          raw = IO.read(examples_file)
+          raw = Zlib::Inflate.inflate(raw).force_encoding('utf-8') if compressed
+          deserialize_examples(raw)
+        end
+
+        def logger
+          Extractor.logger
+        end
+      end
 
       def initialize(collector)
         @collector = collector
-        @compressed = Apipie.configuration.compress_examples
       end
+
 
       def write_examples
         merged_examples = merge_old_new_examples
@@ -28,52 +91,9 @@ module Apipie
         end
       end
 
-      def self.update_action_description(controller, action)
-        updater = ActionDescriptionUpdater.new(controller, action)
-        yield updater
-        updater.write!
-      rescue ActionDescriptionUpdater::ControllerNotFound
-        logger.warn("REST_API: Couldn't find controller file for #{controller}")
-      rescue ActionDescriptionUpdater::ActionNotFound
-        logger.warn("REST_API: Couldn't find action #{action} in #{controller}")
-      end
-
-      def self.write_recorded_examples(examples)
-        examples_file = self.examples_file
-        FileUtils.mkdir_p(File.dirname(examples_file))
-        File.open(examples_file, "w") do |f|
-          f << JSON.pretty_generate(OrderedHash[*examples.sort_by(&:first).flatten(1)])
-        end
-      end
-
-      def self.load_recorded_examples
-        examples_file = self.examples_file
-        if File.exists?(examples_file)
-          return load_json_examples
-        end
-        return {}
-      end
-
-      def self.examples_file
-        pure_path = Rails.root.join(
-          Apipie.configuration.doc_path, 'apipie_examples.json'
-        )
-        zipped_path = pure_path + '.gz'
-        return zipped_path if compressed && File.exist?(zipped_path)
-        pure_path
-      end
 
       protected
 
-      def self.load_json_examples
-        examples = JSON.load(IO.read(examples_file))
-        return {} if examples.nil?
-        examples.each do |method, records|
-          records.each do |record|
-            record["verb"] = record["verb"].to_sym if record["verb"]
-          end
-        end
-      end
 
       def desc_to_s(description)
         "#{description[:controller].name}##{description[:action]}"
@@ -182,10 +202,6 @@ module Apipie
 
       def logger
         self.class.logger
-      end
-
-      def self.logger
-        Extractor.logger
       end
 
       def showable_in_doc?(call)

--- a/spec/lib/extractor/writer_spec.rb
+++ b/spec/lib/extractor/writer_spec.rb
@@ -57,22 +57,38 @@ describe Apipie::Extractor::Writer do
     }
   }
 
-  describe "with doc_path overriden in configuration" do
-    it "should use the doc_path specified in configuration" do
-      Apipie.configuration.doc_path = "user_specified_doc_path"
-      expect(writer_class.examples_file).to eql(File.join(Rails.root, "user_specified_doc_path", "apipie_examples.json"))
+  context 'with doc_path overriden in configuration' do
+    around(:each) do |example|
+      standard_path = Apipie.configuration.doc_path
+      Apipie.configuration.doc_path = 'user_specified_doc_path'
+      example.run
+      Apipie.configuration.doc_path = standard_path
+    end
+
+    it 'should use the doc_path specified in configuration' do
+      expect(writer_class.examples_file).to eql(File.join(Rails.root, 'user_specified_doc_path', 'apipie_examples.json'))
     end
   end
 
   context 'when compressing examples' do
-    before(:each) { Apipie.configuration.compress_examples = true }
+    around(:each) do |example|
+      Apipie.configuration.compress_examples = true
+      example.run
+      FileUtils.rm(writer_class.examples_file) if File.exist?(writer_class.examples_file)
+      Apipie.configuration.compress_examples = nil
+    end
 
-    it 'should write to a compressed file'
-    it 'should read from a compressed file'
+    it 'should write to a compressed file' do
+      expect(writer_class.examples_file).to match(/\.gz$/)
+      writer_class.write_recorded_examples(records)
+      expect(File.exist?(writer_class.examples_file))
+    end
 
-    context 'and the previous configuration did not compress' do
-      it 'writes the next examples into the compressed file'
-      it 'removes the previous file.'
+    it 'should read from a compressed file' do
+      writer_class.write_recorded_examples(records)
+      expected_string = writer_class.send(:serialize_examples, records)
+      expect(writer_class.load_recorded_examples)
+        .to eql(writer_class.send(:deserialize_examples, expected_string))
     end
   end
 

--- a/spec/lib/extractor/writer_spec.rb
+++ b/spec/lib/extractor/writer_spec.rb
@@ -64,6 +64,18 @@ describe Apipie::Extractor::Writer do
     end
   end
 
+  context 'when compressing examples' do
+    before(:each) { Apipie.configuration.compress_examples = true }
+
+    it 'should write to a compressed file'
+    it 'should read from a compressed file'
+
+    context 'and the previous configuration did not compress' do
+      it 'writes the next examples into the compressed file'
+      it 'removes the previous file.'
+    end
+  end
+
   describe "storing of examples" do
     before do
       allow(writer_class).to receive(:examples_file) { test_examples_file }


### PR DESCRIPTION
This PR adds the option (default: false) to compress recorded examples using `Zlib`.
This can be benefitial by keeping examples out of git diffs and in reducing their size for big test suits.