### PR TITLE
Use SHA1 instead of MD5 to enable using APIPIE at FIPS-enables systems

### DIFF
--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -1,7 +1,7 @@
 require 'apipie/static_dispatcher'
 require 'apipie/routes_formatter'
 require 'yaml'
-require 'digest/md5'
+require 'digest/sha1'
 require 'json'
 
 module Apipie
@@ -341,7 +341,7 @@ module Apipie
           all.update(version => Apipie.to_json(version))
         end
       end
-      Digest::MD5.hexdigest(JSON.dump(all_docs))
+      Digest::SHA1.hexdigest(JSON.dump(all_docs))
     end
 
     def checksum


### PR DESCRIPTION
FIPS forbits using MD5 at system level, therefore we need to use
something else inside.