### PR TITLE
Remove binary data from request_data

### DIFF
--- a/lib/apipie/extractor/writer.rb
+++ b/lib/apipie/extractor/writer.rb
@@ -80,6 +80,12 @@ module Apipie
           ordered_call[k] = case call[k]
                      when ActiveSupport::HashWithIndifferentAccess
                        convert_file_value(call[k]).to_hash
+                     when String
+                       if k == "request_data"
+                         remove_binary_data(call[k])
+                       else
+                         call[k]
+                       end
                      else
                        call[k]
                      end
@@ -96,6 +102,14 @@ module Apipie
           end
         end
         hash
+      end
+
+      def remove_binary_data(value)
+        new_value = ""
+        value.each_byte do |c|
+          new_value << c.chr if c==9 || c==10 || c==13 || (c > 31 && c < 127)
+        end
+        new_value
       end
 
       def load_recorded_examples

--- a/spec/lib/extractor/writer_spec.rb
+++ b/spec/lib/extractor/writer_spec.rb
@@ -75,6 +75,44 @@ describe Apipie::Extractor::Writer do
       expect(writer.send(:load_recorded_examples)).to eql(loaded_records)
     end
 
+    context "when binary data exists in request_data" do
+      let(:records) { {
+        "concern_resources#show" =>
+          [{
+            :controller=>ConcernsController,
+            :action=>"show",
+            :verb=>:GET,
+            :path=>"/api/concerns/5",
+            :params=>{},
+            :query=>"session=secret_hash",
+            :request_data=> "\xE2",
+            :response_data=>"OK {\"session\"=>\"secret_hash\", \"id\"=>\"5\", \"controller\"=>\"concerns\", \"action\"=>\"show\"}",
+            :code=>"200"
+          }]
+        }
+      }
+      let(:loaded_records) { {
+        "concern_resources#show" =>
+          [{
+            "verb"=>:GET,
+            "path"=>"/api/concerns/5",
+            "versions"=>["development"],
+            "query"=>"session=secret_hash",
+            "request_data"=>"",
+            "response_data"=>"OK {\"session\"=>\"secret_hash\", \"id\"=>\"5\", \"controller\"=>\"concerns\", \"action\"=>\"show\"}",
+            "code"=>"200",
+            "show_in_doc"=>1,
+            "recorded"=>true
+          }]
+        }
+      }
+
+      it "should read and write examples without encoding errors" do
+        writer.write_examples
+        expect(writer.send(:load_recorded_examples)).to eql(loaded_records)
+      end
+    end
+
     after do
       File.unlink(test_examples_file) if File.exists?(test_examples_file)
     end


### PR DESCRIPTION
On a request spec, we are using a `Rack::Test::UploadedFile` as part of the request params, but since the uploaded file was a PDF, when writing the apipie examples we are getting the following error:

```bash
Writing examples to a file
/home/travis/build/parallel-6/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:34:in `encode': "\xE2" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)
	from /home/travis/build/parallel-6/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:34:in `to_json'
	from /home/travis/build/parallel-6/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.10/lib/active_support/core_ext/object/json.rb:34:in `to_json_with_active_support_encoder'
	from /home/travis/build/parallel-6/vendor/bundle/ruby/2.2.0/bundler/gems/apipie-rails-63414d85c0a0/lib/apipie/extractor/writer.rb:43:in `pretty_generate'
	from /home/travis/build/parallel-6/vendor/bundle/ruby/2.2.0/bundler/gems/apipie-rails-63414d85c0a0/lib/apipie/extractor/writer.rb:43:in `block in write_recorded_examples'
	from /home/travis/build/parallel-6/vendor/bundle/ruby/2.2.0/bundler/gems/apipie-rails-63414d85c0a0/lib/apipie/extractor/writer.rb:42:in `open'
	from /home/travis/build/parallel-6/vendor/bundle/ruby/2.2.0/bundler/gems/apipie-rails-63414d85c0a0/lib/apipie/extractor/writer.rb:42:in `write_recorded_examples'
	from /home/travis/build/parallel-6/vendor/bundle/ruby/2.2.0/bundler/gems/apipie-rails-63414d85c0a0/lib/apipie/extractor/writer.rb:13:in `write_examples'
	from /home/travis/build/parallel-6/vendor/bundle/ruby/2.2.0/bundler/gems/apipie-rails-63414d85c0a0/lib/apipie/extractor.rb:78:in `write_examples'
	from /home/travis/build/parallel-6/vendor/bundle/ruby/2.2.0/bundler/gems/apipie-rails-63414d85c0a0/lib/apipie/extractor.rb:46:in `finish'
	from /home/travis/build/parallel-6/vendor/bundle/ruby/2.2.0/bundler/gems/apipie-rails-63414d85c0a0/lib/apipie/extractor.rb:179:in `block in <top (required)>'
```

I'm not sure this is supported by apipie, but the a workaround was to just remove the unwanted bytes from the request data, as this PR does.

I'm not fully convinced this is "THE" fix.   Any thoughts/ideas?