### PR TITLE
Use underscore when appending `controller` to the default controller string

### DIFF
--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -55,7 +55,7 @@ module Apipie
     # this method does in depth search for the route controller
     def route_app_controller(app, route, visited_apps = [])
       if route.defaults[:controller]
-        controller_name = (route.defaults[:controller] + 'Controller').camelize
+        controller_name = "#{route.defaults[:controller]}_controller".camelize
         controller_name.safe_constantize
       end
     end


### PR DESCRIPTION
The current implementation causes namespaced controllers to fail when using the `api!` dsl method. This is due to `route.defaults[:controller]` being `'api/resource'` which then when `Controller` is added and `camelize` called will result in `Api::Resourcecontroller` instead of `Api::ResourceController`. By appending controller using snake case first results in `_controller` being properly camelized.