### PR TITLE
Swagger json includes apipie's description as swagger's description

### DIFF
--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -223,7 +223,8 @@ module Apipie
             operationId: op_id,
             summary: Apipie.app.translate(api.short_description, @current_lang),
             parameters: swagger_params_array_for_method(ruby_method, api.path),
-            responses: responses
+            responses: responses,
+            description: ruby_method.full_description
         }
 
         if methods[method_key][:summary].nil?


### PR DESCRIPTION
Hi! Thank you for maintaining the greate gem.

## Background
When generating a static Swagger JSON, we are missing `description` parameter.

## What this PR for
To pass apipie's description annotation to swagger's description key. 