### PR TITLE
Allow HTTP and HTTPS schemas in Swagger json

### DIFF
--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -70,6 +70,7 @@ module Apipie
               "x-copyright" => Apipie.configuration.copyright,
           },
           basePath: Apipie.api_base_url(version),
+          schemes: [ "http", "https" ],
           consumes: [],
           paths: {},
           definitions: {},


### PR DESCRIPTION
This PR includes both schemes in Swagger json.