### PR TITLE
Allow ArrayValidator to use other validators to validate array elements

### DIFF
--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -225,7 +225,13 @@ module Apipie
 
       def has_valid_type?(value)
         if @items_type
-          value.kind_of?(@items_type)
+          item_validator = BaseValidator.find('', @items_type, nil, nil)
+
+          if item_validator
+            item_validator.valid?(value)
+          else
+            value.kind_of?(@items_type)
+          end
         else
           true
         end

--- a/spec/lib/validators/array_validator_spec.rb
+++ b/spec/lib/validators/array_validator_spec.rb
@@ -24,18 +24,38 @@ module Apipie::Validator
     end
 
     context "with a constraint on items type" do
-      let(:validator) { ArrayValidator.new(param_desc, Array, :of => String) }
+      let(:validator) { ArrayValidator.new(param_desc, Array, :of => type) }
 
-      it "accepts array of specified type" do
-        expect(validator.validate(['string1', 'string2'])).to eq(true)
+      context "String" do
+        let(:type) { String }
+
+        it "accepts array of specified type" do
+          expect(validator.validate(['string1', 'string2'])).to eq(true)
+        end
+
+        it "accepts empty array" do
+          expect(validator.validate([])).to eq(true)
+        end
+
+        it "does not accepts array with other types" do
+          expect(validator.validate(['string1', true])).to eq(false)
+        end
       end
 
-      it "accepts empty array" do
-        expect(validator.validate([])).to eq(true)
-      end
+      context ":number" do
+        let(:type) { :decimal }
 
-      it "does not accepts array with other types" do
-        expect(validator.validate(['string1', true])).to eq(false)
+        it "accepts array of specified type" do
+          expect(validator.validate([12, '14'])).to eq(true)
+        end
+
+        it "accepts empty array" do
+          expect(validator.validate([])).to eq(true)
+        end
+
+        it "does not accepts array with other types" do
+          expect(validator.validate([12, 'potato'])).to eq(false)
+        end
       end
     end
 


### PR DESCRIPTION
I had a situation where I needed to pass an array of integers in the query string. 

I tried using `array_of: Integer` but this didn't work, because the values was passed in as an array of strings: `["1", "2"]` instead of `[1, 2]`. 

This PR fixes that by allowing ArrayValidator to use other validators to validate the elements of the parameter array. So I was able to use `array_of: :number`. It should work for other validators too because it looks them up with `BaseValidator.find`. 

I also added a spec.