### PR TITLE
Fixes #622 examples not being generated for Rails < 5.0.0.

### DIFF
--- a/lib/apipie/extractor.rb
+++ b/lib/apipie/extractor.rb
@@ -16,7 +16,14 @@ class Apipie::Railtie
       end
     end
     app.middleware.use ::Apipie::Extractor::Recorder::Middleware
-    ActionController::TestCase.send(:prepend, Apipie::Extractor::Recorder::FunctionalTestRecording)
+
+    if Gem::Version.new(Rails.version) < Gem::Version.new('5.0.0')
+      ActionController::TestCase::Behavior.instance_eval do
+        prepend Apipie::Extractor::Recorder::FunctionalTestRecording
+      end
+    else
+      ActionController::TestCase.send(:prepend, Apipie::Extractor::Recorder::FunctionalTestRecording)
+    end
   end
 end
 


### PR DESCRIPTION
fixes https://github.com/Apipie/apipie-rails/issues/622