### PR TITLE
[Bugfix] Stop swagger generation from crashing (if a controller's parent doesn't define a resource_description block)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -283,6 +283,8 @@ Example:
         property :enum1, ['v1', 'v2'], :desc => "One of 2 possible string values"
       end
    end
+   tags %w[profiles logins]
+   tags 'more', 'related', 'resources'
    description "method description"
    formats ['json', 'jsonp', 'xml']
    meta :message => "Some very important info"

--- a/lib/apipie/method_description.rb
+++ b/lib/apipie/method_description.rb
@@ -101,7 +101,7 @@ module Apipie
       parent = Apipie.get_resource_description(@resource.controller.superclass)
 
       # get tags from parent resource description
-      parent_tags = [parent, @resource].flat_map { |resource| resource._tag_list_arg }
+      parent_tags = [parent, @resource].compact.flat_map { |resource| resource._tag_list_arg }
       Apipie::TagListDescription.new((parent_tags + @tag_list).uniq.compact)
     end
 

--- a/spec/dummy/app/controllers/tagged_cats_controller.rb
+++ b/spec/dummy/app/controllers/tagged_cats_controller.rb
@@ -3,7 +3,7 @@
 # defining a set of tags for the contained methods to include.
 #
 
-class TaggedCatsController < ApplicationController
+class TaggedCatsController < ActionController::Base
   resource_description do
     description 'A controller to test "returns"'
     short 'Pets'

--- a/spec/dummy/app/controllers/tagged_dogs_controller.rb
+++ b/spec/dummy/app/controllers/tagged_dogs_controller.rb
@@ -1,0 +1,15 @@
+#
+# The TagsController defined here provides an example of a
+# tags call without a resource description.
+#
+
+class TaggedDogsController < ActionController::Base
+  #-----------------------------------------------------------
+  # simple 'returns' example: a method that returns a cat record
+  #-----------------------------------------------------------
+  api :GET, "/pets/:id/as_properties", "Get a dog record"
+  tags(%w[Dogs Wolves])
+  def show_as_properties
+    render :plain => "showing pet properties"
+  end
+end

--- a/spec/lib/swagger/swagger_dsl_spec.rb
+++ b/spec/lib/swagger/swagger_dsl_spec.rb
@@ -449,6 +449,27 @@ describe "Swagger Responses" do
   end
 
   #==============================================================================
+  # TaggedDogsController is a demonstration of how tags may be defined in a simple
+  # controller class without defining either the controller resource-description
+  # block or the controller's superclass's resource-description block.
+  #==============================================================================
+
+  describe TaggedDogsController do
+    describe "TaggedDogsController#show_as_properties" do
+      subject do
+        desc._methods[:show_as_properties]
+      end
+
+      it "should return tags with 'Dogs', and 'Wolves'" do
+        returns_obj = subject.tag_list
+        puts returns_obj.inspect
+
+        expect(returns_obj.tags).to eq(%w[Dogs Wolves])
+      end
+    end
+  end
+
+  #==============================================================================
   # TaggedCatsController is a demonstration of how tags may be defined in the
   # controller's resource description so that they may be automatically prefixed
   # to a particular operation's tags.


### PR DESCRIPTION
The original feature release caused Apipie's swagger generator (`rake apipie:static_swagger_json`) to crash with this error:

```ruby
NoMethodError: undefined method `_tag_list_arg’ for nil:NilClass
```

Unless you happened to define a `resource_description` for the parent class of a controller. (It turns out the `parent` variable isn't always a resource-desc object.)

This makes sure `_tag_list_arg` is called on non-nil objects only. I marked this as a bugfix because the error message you get doesn't explain how to fix it, and we shouldn't have to define `resource_description` for the parent classes.

`0.5.11` should be marked as faulty. Sorry about that.