### PR TITLE
Fixes #629

### DIFF
--- a/lib/apipie/extractor.rb
+++ b/lib/apipie/extractor.rb
@@ -23,6 +23,7 @@ class Apipie::Railtie
       end
     else
       ActionController::TestCase.send(:prepend, Apipie::Extractor::Recorder::FunctionalTestRecording)
+      ActionController::TestCase::Behavior.send(:prepend, Apipie::Extractor::Recorder::FunctionalTestRecording)
     end
   end
 end


### PR DESCRIPTION
The `FunctionalTestRecording` module's version of `process()` was not being called when running tests, which meant `@collector` was never initialized and so examples were not written to the file.
To fix this, we need to prepend `FunctionalTestRecording` to `ActionController::TestCase::Behavior`, not `ActionController::TestCase`, for reasons which I honestly did not manage to determine. (You can follow some of my debug rambling in the original issue.)

I'm not actually clear if this fix is safe to merge as is; presumably the original version is there for a reason, I'd've expected the `prepend()` to apply to the subclass as well as the parent, and this may be more version-specific than I'm giving it credit for. My testing was all done against APIPie 0.5.13 and Rails 5.1.6 and Ruby 2.5.1 and RSpec 3.7.2. The full codebase is available at [https://github.com/Marri/glowfic](https://github.com/Marri/glowfic).