### PR TITLE
Support for adding new params via `update_api`

### DIFF
--- a/lib/apipie/dsl_definition.rb
+++ b/lib/apipie/dsl_definition.rb
@@ -498,7 +498,7 @@ module Apipie
           params_ordered = dsl_data[:params].map do |args|
             Apipie::ParamDescription.from_dsl_data(method_description, args)
           end
-          ParamDescription.unify(method_description.params_ordered_self + params_ordered)
+          ParamDescription.merge(method_description.params_ordered_self, params_ordered)
         end
       end
 

--- a/lib/apipie/param_description.rb
+++ b/lib/apipie/param_description.rb
@@ -197,6 +197,14 @@ module Apipie
       end.sort_by { |param| ordering.index(param.name) }
     end
 
+    def self.merge(target_params, source_params)
+      params_to_merge, params_to_add = source_params.partition do |source_param|
+        target_params.any? { |target_param| source_param.name == target_param.name }
+      end
+      unify(target_params + params_to_merge)
+      target_params.concat(params_to_add)
+    end
+
     # action awareness is being inherited from ancestors (in terms of
     # nested params)
     def action_aware?

--- a/spec/controllers/extended_controller_spec.rb
+++ b/spec/controllers/extended_controller_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 describe ExtendedController do
 
   it 'should include params from both original controller and extending concern' do
+    expect(Apipie["extended#create"].params.keys).to eq [:oauth, :user, :admin]
     user_param = Apipie["extended#create"].params[:user]
     expect(user_param.validator.params_ordered.map(&:name)).to eq [:name, :password, :from_concern]
   end

--- a/spec/dummy/app/controllers/extended_controller.rb
+++ b/spec/dummy/app/controllers/extended_controller.rb
@@ -7,4 +7,8 @@ class ExtendedController < ApplicationController
   end
   def create
   end
+
+  apipie_update_params([:create]) do
+    param :admin, :boolean
+  end
 end


### PR DESCRIPTION
Before this patch, we only supported updating nested hashes. For example

      param :user, Hash do
        param :login, String
      end

and

      param :user, Hash do
        param :oauth, String
      end

has been merged properly. However when merging top-level params, such as

      param :login, String

and

      param :oauth, String

no changes were propagated.