### PR TITLE
HTML escape validator values

### DIFF
--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -57,6 +57,10 @@ module Apipie
         "TODO: validator description"
       end
 
+      def format_description_value(value)
+        "<code>#{CGI::escapeHTML(value.to_s)}</code>"
+      end
+
       def error
         ParamInvalid.new(param_name, @error_value, description)
       end
@@ -148,7 +152,7 @@ module Apipie
       end
 
       def description
-        "Must match regular expression <code>/#{@regexp.source}/</code>."
+        "Must match regular expression #{format_description_value("/#{@regexp.source}/")}."
       end
     end
 
@@ -172,7 +176,7 @@ module Apipie
       end
 
       def description
-        string = @array.map { |value| "<code>#{value}</code>" }.join(', ')
+        string = @array.map { |value| format_description_value(value) }.join(', ')
         "Must be one of: #{string}."
       end
     end
@@ -272,7 +276,8 @@ module Apipie
       end
 
       def description
-        "Must be one of: #{@array.join(', ')}."
+        string = @array.map { |value| format_description_value(value) }.join(', ')
+        "Must be one of: #{string}."
       end
     end
 
@@ -467,8 +472,8 @@ module Apipie
       end
 
       def description
-        string = %w(true false 1 0).map { |value| "<code>#{value}</code>" }.join(', ')
-        "Must be one of: #{string}"
+        string = %w(true false 1 0).map { |value| format_description_value(value) }.join(', ')
+        "Must be one of: #{string}."
       end
     end
 

--- a/spec/lib/validator_spec.rb
+++ b/spec/lib/validator_spec.rb
@@ -50,12 +50,64 @@ describe Apipie::Validator do
     end
   end
 
+  describe 'BooleanValidator' do
+    it "should validate by object class" do
+      validator = Apipie::Validator::BooleanValidator.new(params_desc)
+      expect(validator.validate("1")).to be_truthy
+      expect(validator.validate(1)).to be_truthy
+      expect(validator.validate(true)).to be_truthy
+      expect(validator.validate(0)).to be_truthy
+      expect(validator.validate(false)).to be_truthy
+      expect(validator.validate({ 1 => 1 })).to be_falsey
+    end
+
+    it "should have a valid description" do
+      validator = Apipie::Validator::BooleanValidator.new(params_desc)
+      expect(validator.description).to eq('Must be one of: <code>true</code>, <code>false</code>, <code>1</code>, <code>0</code>.')
+    end
+  end
+
   describe 'ArrayClassValidator' do
     it "should validate by object class" do
       validator = Apipie::Validator::ArrayClassValidator.new(params_desc, [Fixnum, String])
       expect(validator.validate("1")).to be_truthy
       expect(validator.validate(1)).to be_truthy
       expect(validator.validate({ 1 => 1 })).to be_falsey
+    end
+
+    it "should have a valid description" do
+      validator = Apipie::Validator::ArrayClassValidator.new(params_desc, [Float, String])
+      expect(validator.description).to eq('Must be one of: <code>Float</code>, <code>String</code>.')
+    end
+  end
+
+  describe 'RegexpValidator' do
+    it "should validate by object class" do
+      validator = Apipie::Validator::RegexpValidator.new(params_desc, /^valid( extra)*$/)
+      expect(validator.validate("valid")).to be_truthy
+      expect(validator.validate("valid extra")).to be_truthy
+      expect(validator.validate("valid extra extra")).to be_truthy
+      expect(validator.validate("invalid")).to be_falsey
+    end
+
+    it "should have a valid description" do
+      validator = Apipie::Validator::RegexpValidator.new(params_desc, /^valid( extra)*$/)
+      expect(validator.description).to eq('Must match regular expression <code>/^valid( extra)*$/</code>.')
+    end
+  end
+
+  describe 'EnumValidator' do
+    it "should validate by object class" do
+      validator = Apipie::Validator::EnumValidator.new(params_desc, ['first', 'second & third'])
+      expect(validator.validate("first")).to be_truthy
+      expect(validator.validate("second & third")).to be_truthy
+      expect(validator.validate(1)).to be_falsey
+      expect(validator.validate({ 1 => 1 })).to be_falsey
+    end
+
+    it "should have a valid description" do
+      validator = Apipie::Validator::EnumValidator.new(params_desc, ['first', 'second & third'])
+      expect(validator.description).to eq('Must be one of: <code>first</code>, <code>second &amp; third</code>.')
     end
   end
 end


### PR DESCRIPTION
This fixes an issue when a validator includes a & that needs to be escaped in HTML.