### PR TITLE
Use configured value when swagger_content_type_input argument is not passed

### DIFF
--- a/lib/tasks/apipie.rake
+++ b/lib/tasks/apipie.rake
@@ -191,7 +191,7 @@ namespace :apipie do
 
   def generate_swagger_using_args(args, out)
     args.with_defaults(:version => Apipie.configuration.default_version,
-                       :swagger_content_type_input => :form_data,
+                       :swagger_content_type_input => Apipie.configuration.swagger_content_type_input || :form_data,
                        :filename_suffix => nil)
     Apipie.configuration.swagger_content_type_input = args[:swagger_content_type_input].to_sym
     count = 0


### PR DESCRIPTION
Hi.
I think it would be better to use configured `swagger_content_type_input` value as default value of `rake apipie:static_swagger_json` option.
Or at least I'd like to update README.md. What do you think?