### PR TITLE
Reverted conditional assignment operators that caused #559

### DIFF
--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -237,13 +237,13 @@ module Apipie
 
     # initialize variables for gathering dsl data
     def init_env
-      @resource_descriptions ||= HashWithIndifferentAccess.new { |h, version| h[version] = {} }
-      @controller_to_resource_id ||= {}
-      @param_groups ||= {}
+      @resource_descriptions = HashWithIndifferentAccess.new { |h, version| h[version] = {} }
+      @controller_to_resource_id = {}
+      @param_groups = {}
       @swagger_generator = Apipie::SwaggerGenerator.new(self)
 
       # what versions does the controller belong in (specified by resource_description)?
-      @controller_versions ||= Hash.new { |h, controller| h[controller.to_s] = [] }
+      @controller_versions = Hash.new { |h, controller| h[controller.to_s] = [] }
     end
 
     def recorded_examples


### PR DESCRIPTION
69c5bdcf51cb0d6a73a6cbf75dc4f58097f1f7e0 introduced a regression described in #559:

```bash
deltik@demo:~/apipie-rails$ git bisect log
git bisect start
# bad: [b56351f7bfae5e7fb4c55f2fa0e3f70d0015acdc] added the required param to the docs
git bisect bad b56351f7bfae5e7fb4c55f2fa0e3f70d0015acdc
# good: [c9da7603035b82523822e75d3cec10ed8e99a877] Bump version to 0.5.1
git bisect good c9da7603035b82523822e75d3cec10ed8e99a877
# bad: [e9075fcc5aeea8dcdc7e1c8a4b80eaab06559685] new validator - DecimalValidator
git bisect bad e9075fcc5aeea8dcdc7e1c8a4b80eaab06559685
# bad: [71f96079addc0bc7b884ce1ebbf9166cf3c1e96c] Prevent missing translation span in title
git bisect bad 71f96079addc0bc7b884ce1ebbf9166cf3c1e96c
# bad: [a4e8127c7d18cbc73552389420bda0bb28da6b4c] Bump version to 0.5.3
git bisect bad a4e8127c7d18cbc73552389420bda0bb28da6b4c
# good: [cfb42198bc39b5b30d953ba5a8b523bafdb4f897] A way to extend an exiting API via concern
git bisect good cfb42198bc39b5b30d953ba5a8b523bafdb4f897
# good: [21894283fac5bcf43b62c530bc7d75b815032227] Fix example recording when using send_file
git bisect good 21894283fac5bcf43b62c530bc7d75b815032227
# bad: [69c5bdcf51cb0d6a73a6cbf75dc4f58097f1f7e0] Fix reloading when extending the apidoc from concern
git bisect bad 69c5bdcf51cb0d6a73a6cbf75dc4f58097f1f7e0
# first bad commit: [69c5bdcf51cb0d6a73a6cbf75dc4f58097f1f7e0] Fix reloading when extending the apidoc from concern
```

No tests were added to describe what would happen when this change was applied in that commit:

```diff
@@ -236,12 +236,12 @@ module Apipie
 
     # initialize variables for gathering dsl data
     def init_env
-      @resource_descriptions = HashWithIndifferentAccess.new { |h, version| h[version] = {} }
-      @controller_to_resource_id = {}
-      @param_groups = {}
+      @resource_descriptions ||= HashWithIndifferentAccess.new { |h, version| h[version] = {} }
+      @controller_to_resource_id ||= {}
+      @param_groups ||= {}
 
       # what versions does the controller belong in (specified by resource_description)?
-      @controller_versions = Hash.new { |h, controller| h[controller] = [] }
+      @controller_versions ||= Hash.new { |h, controller| h[controller.to_s] = [] }
     end
 
     def recorded_examples
```

Replacing `||=` with `=` fixes the regression, and all the existing tests still pass as a result of the change.

I have not been able to figure out what Rails does differently when `Rails.application.config.cache_classes == false` that triggers #559, so I couldn't craft a new test to prevent this regression from happening again.

----

Fixes: #559