### PR TITLE
Load file directly instead of using Rails constant loading to do so

### DIFF
--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -434,8 +434,7 @@ module Apipie
     end
 
     def load_controller_from_file(controller_file)
-      controller_class_name = controller_file.gsub(/\A.*\/app\/controllers\//,"").gsub(/\.\w*\Z/,"").camelize
-      controller_class_name.constantize
+      require_dependency controller_file
     end
 
     def ignored?(controller, method = nil)


### PR DESCRIPTION
- Since Rails constant loading looks in Rails load paths, it's possible
  for files outside of api_controllers_matcher to be loaded
- Files that do not define an expected constant will cause a NameError
  to be raised.  This was most commonly encountered with files in the
  concerns/ directory, which caused a NameError for a missing
  "Concerns::<name>" constant.

This make use of ActiveSupport::Dependencies::Loadable#require_dependency
to explicitly load the file and its constants in a way that cooperates
with Rails constant loading and unloading.

https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#require-dependency
https://api.rubyonrails.org/classes/ActiveSupport/Dependencies/Loadable.html#method-i-require_dependency

Fixes #347.