### PR TITLE
Allows update metadata for methods

### DIFF
--- a/lib/apipie/method_description.rb
+++ b/lib/apipie/method_description.rb
@@ -17,7 +17,8 @@ module Apipie
 
     end
 
-    attr_reader :full_description, :method, :resource, :apis, :examples, :see, :formats, :metadata, :headers, :show
+    attr_reader :full_description, :method, :resource, :apis, :examples, :see, :formats, :headers, :show
+    attr_accessor :metadata
 
     def initialize(method, resource, dsl_data)
       @method = method.to_s

--- a/spec/controllers/extended_controller_spec.rb
+++ b/spec/controllers/extended_controller_spec.rb
@@ -7,5 +7,8 @@ describe ExtendedController do
     user_param = Apipie["extended#create"].params[:user]
     expect(user_param.validator.params_ordered.map(&:name)).to eq [:name, :password, :from_concern]
   end
-end
 
+  it 'should include updated metadata' do
+    expect(Apipie['extended#create'].metadata).to eq metadata: 'data'
+  end
+end

--- a/spec/dummy/app/controllers/concerns/extending_concern.rb
+++ b/spec/dummy/app/controllers/concerns/extending_concern.rb
@@ -6,6 +6,7 @@ module Concerns
       param :user, Hash do
         param :from_concern, String, :desc => 'param from concern', :allow_nil => false
       end
+      meta metadata: 'data'
     end
   end
 end


### PR DESCRIPTION
`update_api` block allows to update method `params` only. This fix adds a possibility to use `meta` method inside of the block:

```ruby
update_api(:index) do
  meta metadata: 'data'
end
```

Also, there is a place for allowing usage of other similar methods. Just use the following pattern:
```ruby
# define method responsible for updating method's data
def _apipie_update_something(method_desc, dsl_data)
  # ...
end
# then invoke it next to others
def apipie_update_methods(methods, *args, &block)
  # ...
  _apipie_update_params(method_desc, dsl_data)
  # ...
  _apipie_update_something(method_desc, dsl_data)
  # ...
end
```