### PR TITLE
Apply streaming fix to apipie-rails master

### DIFF
--- a/lib/apipie/extractor.rb
+++ b/lib/apipie/extractor.rb
@@ -15,15 +15,18 @@ class Apipie::Railtie
         end
       end
     end
-    app.middleware.use ::Apipie::Extractor::Recorder::Middleware
 
-    if Gem::Version.new(Rails.version) < Gem::Version.new('5.0.0')
-      ActionController::TestCase::Behavior.instance_eval do
-        prepend Apipie::Extractor::Recorder::FunctionalTestRecording
+    if Apipie.configuration.record
+      app.middleware.use ::Apipie::Extractor::Recorder::Middleware
+
+      if Gem::Version.new(Rails.version) < Gem::Version.new('5.0.0')
+        ActionController::TestCase::Behavior.instance_eval do
+          prepend Apipie::Extractor::Recorder::FunctionalTestRecording
+        end
+      else
+        ActionController::TestCase.send(:prepend, Apipie::Extractor::Recorder::FunctionalTestRecording)
+        ActionController::TestCase::Behavior.send(:prepend, Apipie::Extractor::Recorder::FunctionalTestRecording)
       end
-    else
-      ActionController::TestCase.send(:prepend, Apipie::Extractor::Recorder::FunctionalTestRecording)
-      ActionController::TestCase::Behavior.send(:prepend, Apipie::Extractor::Recorder::FunctionalTestRecording)
     end
   end
 end

--- a/lib/apipie/extractor.rb
+++ b/lib/apipie/extractor.rb
@@ -19,14 +19,8 @@ class Apipie::Railtie
     if Apipie.configuration.record
       app.middleware.use ::Apipie::Extractor::Recorder::Middleware
 
-      if Gem::Version.new(Rails.version) < Gem::Version.new('5.0.0')
-        ActionController::TestCase::Behavior.instance_eval do
-          prepend Apipie::Extractor::Recorder::FunctionalTestRecording
-        end
-      else
-        ActionController::TestCase.send(:prepend, Apipie::Extractor::Recorder::FunctionalTestRecording)
-        ActionController::TestCase::Behavior.send(:prepend, Apipie::Extractor::Recorder::FunctionalTestRecording)
-      end
+      ActionController::TestCase.send(:prepend, Apipie::Extractor::Recorder::FunctionalTestRecording)
+      ActionController::TestCase::Behavior.send(:prepend, Apipie::Extractor::Recorder::FunctionalTestRecording)
     end
   end
 end


### PR DESCRIPTION
`apipie-rails` prevents developers from streaming responses:

```ruby
begin
  response.headers['Content-Type'] = 'text/event-stream'
  response.stream.write "[\n"
  # ...
  response.stream.write "\n]\n"
ensure
  response.stream.close unless response.stream.closed?
end
```

This appears to be due to the middleware `::Apipie::Extractor::Recorder::Middleware`, which should only be enabled when configured to do so.