### PR TITLE
Optional rdoc dependency with lazyload

### DIFF
--- a/lib/apipie/markup.rb
+++ b/lib/apipie/markup.rb
@@ -4,20 +4,23 @@ module Apipie
 
     class RDoc
 
-      def initialize
-        require 'rdoc'
-        require 'rdoc/markup/to_html'
-        if Gem::Version.new(::RDoc::VERSION) < Gem::Version.new('4.0.0')
-          @rdoc ||= ::RDoc::Markup::ToHtml.new()
-        else
-          @rdoc ||= ::RDoc::Markup::ToHtml.new(::RDoc::Options.new)
+      def to_html(text)
+        rdoc.convert(text)
+      end
+
+      private
+
+      def rdoc
+        @rdoc ||= begin
+          require 'rdoc'
+          require 'rdoc/markup/to_html'
+          if Gem::Version.new(::RDoc::VERSION) < Gem::Version.new('4.0.0')
+            ::RDoc::Markup::ToHtml.new()
+          else
+            ::RDoc::Markup::ToHtml.new(::RDoc::Options.new)
+          end
         end
       end
-
-      def to_html(text)
-        @rdoc.convert(text)
-      end
-
     end
 
     class Markdown


### PR DESCRIPTION
Lazyloads rdoc for the defualt `Apipie::Markup::RDoc` to prevent errors on
require: `cannot load such file -- rdoc (LoadError)`.

Resolves: #544 