### PR TITLE
Fix Ruby 2.7 keyword arguments deprecation warnings

### DIFF
--- a/lib/apipie/extractor/recorder.rb
+++ b/lib/apipie/extractor/recorder.rb
@@ -150,8 +150,8 @@ module Apipie
       end
 
       module FunctionalTestRecording
-        def process(*args) # action, parameters = nil, session = nil, flash = nil, http_method = 'GET')
-          ret = super(*args)
+        def process(*args, **kwargs) # action, parameters = nil, session = nil, flash = nil, http_method = 'GET')
+          ret = super(*args, **kwargs)
           if Apipie.configuration.record
             Apipie::Extractor.call_recorder.analyze_functional_test(self)
             Apipie::Extractor.call_finished


### PR DESCRIPTION
This fixes the following warnings that are printed when using this gem with Ruby 2.7.1:

```
/root/project/vendor/bundle/ruby/2.7.0/gems/apipie-rails-0.5.18/lib/apipie/extractor/recorder.rb:154: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/root/project/vendor/bundle/ruby/2.7.0/gems/actionpack-6.0.3.1/lib/action_controller/test_case.rb:460: warning: The called method `process' is defined here
```

`#process` is defined here:
https://github.com/rails/rails/blob/v6.0.3.1/actionpack/lib/action_controller/test_case.rb#L460