### PR TITLE
Alter word Parâmentros locale pt-BR

### DIFF
--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -16,7 +16,7 @@
     optional: opcional
     nil_allowed: nulo permitido
     param_name: Nome parâmetro
-    params: Parâmentros
+    params: Parâmetros
     examples: Exemplos
     metadata: Metadado
     errors: Erros


### PR DESCRIPTION
Correcting the word Parâmentros, the correct one in Brazilian Portuguese is Parâmetros