### PR TITLE
Skip extra parameters while validating the keys.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -966,6 +966,9 @@ validate_presence
 validate_key
   Check the received params to ensure they are defined in the API. (false by default)
 
+action_on_non_validated_keys
+  Either `:raise` or `:skip`. If `validate_key` fails, raise error or skip and log the key (`:raise` by default)
+
 process_params
   Process and extract the parameter defined from the params of the request
   to the api_params variable

--- a/README.rst
+++ b/README.rst
@@ -967,7 +967,7 @@ validate_key
   Check the received params to ensure they are defined in the API. (false by default)
 
 action_on_non_validated_keys
-  Either `:raise` or `:skip`. If `validate_key` fails, raise error or skip and log the key (`:raise` by default)
+  Either `:raise` or `:skip`. If `validate_key` fails, raise error or delete the non-validated key from the params and log the key (`:raise` by default)
 
 process_params
   Process and extract the parameter defined from the params of the request

--- a/lib/apipie/configuration.rb
+++ b/lib/apipie/configuration.rb
@@ -5,7 +5,7 @@ module Apipie
       :markup, :disqus_shortname,
       :api_base_url, :doc_base_url, :required_by_default, :layout,
       :default_version, :debug, :version_in_url, :namespaced_resources,
-      :validate, :validate_value, :validate_presence, :validate_key, :authenticate, :doc_path,
+      :validate, :validate_value, :validate_presence, :validate_key, :action_on_non_validated_keys, :authenticate, :doc_path,
       :show_all_examples, :process_params, :update_checksum, :checksum_path,
       :link_extension, :record, :languages, :translate, :locale, :default_locale,
       :persist_show_in_doc, :authorize,
@@ -152,6 +152,7 @@ module Apipie
       @validate_value = true
       @validate_presence = true
       @validate_key = false
+      @action_on_non_validated_keys = :raise
       @required_by_default = false
       @api_base_url = HashWithIndifferentAccess.new
       @doc_base_url = "/apipie"

--- a/lib/apipie/dsl_definition.rb
+++ b/lib/apipie/dsl_definition.rb
@@ -262,7 +262,9 @@ module Apipie
               if Apipie.configuration.validate_key?
                 params.reject{|k,_| %w[format controller action].include?(k.to_s) }.each_pair do |param, _|
                   # params allowed
-                  raise UnknownParam.new(param) if method_params.select {|_,p| p.name.to_s == param.to_s}.empty?
+                  if method_params.select {|_,p| p.name.to_s == param.to_s}.empty?
+                    self.class._apipie_handle_validate_key_error params, param
+                  end
                 end
               end
 
@@ -287,6 +289,15 @@ module Apipie
             end
           end
 
+        end
+      end
+
+      def _apipie_handle_validate_key_error params, param
+        if Apipie.configuration.action_on_non_validated_keys == :raise
+          raise UnknownParam, param
+        elsif Apipie.configuration.action_on_non_validated_keys == :skip
+          params.delete(param)
+          Rails.logger.warn(UnknownParam.new(param).to_s)
         end
       end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -128,7 +128,7 @@ describe UsersController do
           before do
             Apipie.configuration.validate_value = false
             Apipie.configuration.validate_presence = true
-            Apipie.configuration.validate_key = true
+            Apipie.configuration.validate_key = false
             Apipie.configuration.action_on_non_validated_keys = :skip
           end
 
@@ -137,8 +137,9 @@ describe UsersController do
             assert_response :success
           end
 
-          it "should not fail even if extra parameter is passed in" do
+          it "should delete the param and not fail if an extra parameter is passed." do
             expect { get :show, :params => { :id => 5 , :badparam => 'badfoo', :session => "secret_hash" }}.not_to raise_error
+            expect(controller.params.as_json).to eq({"session"=>"secret_hash", "id"=>"5", "controller"=>"users", "action"=>"show"})
           end
 
           after do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -128,7 +128,7 @@ describe UsersController do
           before do
             Apipie.configuration.validate_value = false
             Apipie.configuration.validate_presence = true
-            Apipie.configuration.validate_key = false
+            Apipie.configuration.validate_key = true
             Apipie.configuration.action_on_non_validated_keys = :skip
           end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -124,6 +124,28 @@ describe UsersController do
           end
         end
 
+        context "key validations are enabled and skip on non-validated keys" do
+          before do
+            Apipie.configuration.validate_value = false
+            Apipie.configuration.validate_presence = true
+            Apipie.configuration.validate_key = true
+            Apipie.configuration.action_on_non_validated_keys = :skip
+          end
+
+          it "should reply to valid request" do
+            expect { get :show, :params => { :id => 5, :session => 'secret_hash' }}.not_to raise_error
+            assert_response :success
+          end
+
+          it "should not fail even if extra parameter is passed in" do
+            expect { get :show, :params => { :id => 5 , :badparam => 'badfoo', :session => "secret_hash" }}.not_to raise_error
+          end
+
+          after do
+            Apipie.configuration.action_on_non_validated_keys = :raise
+          end
+        end
+
         context "presence and value validations are enabled" do
           before do
             Apipie.configuration.validate_value = true


### PR DESCRIPTION
Currently, `validate_key` can be used to check whether any API is getting any extra parameters. The default behavior of `validate_key` is to raise an error if any unwanted parameter is found.

However, in many scenarios, I'd like to just ignore those extra parameters (i.e. those parameters should get deleted from the params) such that my controller action finally gets exactly what is defined. 

Currently, in order to achieve this, we have to again define those parameters which are required by our API. For example. we would do something like `params.permit(..)`. However, it'll be really great if I don't have to re-define those parameters at two places. Instead, apipie itself just deletes or ignores the unwanted or extra parameters.

This pull request defines one more key called as `action_on_non_validated_keys` which controls the default behavior of `validate_keys`. 
If `action_on_non_validated_keys` is set to `:raise`, it will work as it currently does. i.e. raising an error. (default behavior).
If `action_on_non_validated_keys` is set to `skip`, it will ignore the parameter and log the param without raising an error. By ignoring, it will delete that param from the params hash which are passed to the controller action.