### PR TITLE
Display params in a nested format also in the API doc HTML.

### DIFF
--- a/app/views/apipie/apipies/_method_detail.erb
+++ b/app/views/apipie/apipies/_method_detail.erb
@@ -24,6 +24,7 @@
 
 <% unless method[:params].blank? %>
   <%= heading(t('apipie.params'), h_level) %>
+  <%= render(:partial => "params_simple", :locals => {:params => method[:params]}) %>
   <table class='table'>
     <thead>
       <tr>
@@ -44,6 +45,7 @@
       <%= heading("#{t('apipie.description')}:", h_level + 2) %>
       <p><%= item[:description] %></p>
     <% end %>
+    <%= render(:partial => "params_simple", :locals => {:params => item[:returns_object]}) %>
     <table class='table'>
       <thead>
         <tr>

--- a/app/views/apipie/apipies/_params.html.erb
+++ b/app/views/apipie/apipies/_params.html.erb
@@ -5,7 +5,7 @@
     <%= render(:partial => "params", :locals => {:level => level, :params => param[:params]}) unless param[:params].blank? %>
     <% next %>
   <% end %>
-  <tr style='background-color:rgb(<%= "#{col},#{col},#{col}" %>);'>
+  <tr id="<%= param[:full_name] %>" style='background-color:rgb(<%= "#{col},#{col},#{col}" %>);'>
     <td>
       <strong><%= param[:full_name] %> </strong><br>
       <small>

--- a/app/views/apipie/apipies/_params_simple.html.erb
+++ b/app/views/apipie/apipies/_params_simple.html.erb
@@ -7,7 +7,7 @@
     <li>
       <span>
         <b>
-          <a href="#<%= param[:full_name] %>" data-toggle="tooltip" data-placement="top" title="<%= param[:description] ? param[:description].html_safe : param[:name] %>">
+          <a href="#<%= param[:full_name] %>" data-toggle="tooltip" data-placement="top" title="<%= param[:description] ? param[:description] : param[:name] %>">
             <%= param[:name] %>
           </a>
         </b>
@@ -25,7 +25,7 @@
                 <span> { </span>
               <%- elsif param[:expected_type] == "array" %>
                     <span> [ </span>
-              <%- if param[:expected_type] == "array" && param[:params].blank? %>
+              <%- if param[:params].blank? %>
                     <%= param[:validator].html_safe %>
                 <span> ] </span>
                 <% end %>

--- a/app/views/apipie/apipies/_params_simple.html.erb
+++ b/app/views/apipie/apipies/_params_simple.html.erb
@@ -1,0 +1,48 @@
+<ul>
+  <% params.each do |param| %>
+    <% if !param[:show] %>
+      <%= render(:partial => "params_simple", :locals => {:params => param[:params]}) unless param[:params].blank? %>
+      <% next %>
+    <% end %>
+    <li>
+      <span>
+        <b>
+          <a href="#<%= param[:full_name] %>" data-toggle="tooltip" data-placement="top" title="<%= param[:description] ? param[:description].html_safe : param[:name] %>">
+            <%= param[:name] %>
+          </a>
+        </b>
+      </span>
+      <%- if param[:required] %>
+        <span style="color: red">* </span>
+      <%- end %>
+      <%- if param[:validator].present? %>
+        <span>: </span>
+        <span style="margin-left: 10px;">
+            <% if param[:validator].include? "one of" %>
+              <%= param[:validator].html_safe %>
+            <%- else %>
+              <%- if param[:expected_type] == "hash" %>
+                <span> { </span>
+              <%- elsif param[:expected_type] == "array" %>
+                    <span> [ </span>
+              <%- if param[:expected_type] == "array" && param[:params].blank? %>
+                    <%= param[:validator].html_safe %>
+                <span> ] </span>
+                <% end %>
+              <%- else %>
+                <%= param[:expected_type].html_safe %>
+              <%- end %>
+            <% end %>
+        </span>
+      <%- end %>
+    </li>
+    <% if param[:params].present? %>
+      <%= render(:partial => "params_simple", :locals => {:params => param[:params]}) unless param[:params].blank? %>
+      <%- if param[:expected_type] == "hash" %>
+        <span> } </span>
+      <%- elsif param[:expected_type] == "array" %>
+        <span> ] </span>
+      <%- end %>
+    <% end %>
+  <% end %>
+</ul>


### PR DESCRIPTION
Currently, if the parameters are deeply nested, it is very difficult to understand and comprehend the structure of the request and response params when viewing the API doc in the HTML format. This pull request is an attempt to display these nested parameters in a better way so that we can understand its structure in one go.

**Current**:

![image](https://user-images.githubusercontent.com/21145429/89025553-afddb180-d344-11ea-90ff-b58430aa54f9.png)

**Proposed**:

![image](https://user-images.githubusercontent.com/21145429/89025478-90468900-d344-11ea-8fbe-2e243b38ee38.png)

Note that the current structure is still there in the HTML. I have just supplemented that with this nested HTML structure having an hyperlink to the "normal" params.
Also, I have added tooltips which display the description of the params.

The entire idea is to grasp the entire request / response schema in one go. Please let me know what you think.