### PR TITLE
Fixed issue where scope is nil when a param_group is used inside an array_of_hash

### DIFF
--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -333,6 +333,7 @@ module Apipie
         @params_ordered ||= _apipie_dsl_data[:params].map do |args|
           options = args.find { |arg| arg.is_a? Hash }
           options[:parent] = self.param_description
+          options[:param_group] = @param_group
           Apipie::ParamDescription.from_dsl_data(param_description.method_description, args)
         end
       end


### PR DESCRIPTION
When a param_group is used inside an array_of_hash and the param_group is in a different module / controller, the scope is set to nil, when the param_group is initialized.
This leads to this error: 
```apipie-rails/lib/apipie/dsl_definition.rb:379:in `param_group': undefined method `apipie_concern?' for nil:NilClass (NoMethodError)```

Steps to reproduce:
In a different module define the following param_group:

module UsersSchema:
```
 module UsersSchema
   def self.included(klazz)
     klazz.def_param_group :index_users do
       property :response, Hash do
          property :users, array_of: Hash do
            param_group :extended_users_schema
          end
       end
     end
     klazz.def_param_group :extended_users_schema do
        property :id, Integer, :desc => 'ID of the user'
     end
   end
 end
```

The `:extended_users_schema` gets a scope of nil and a scope has to be explicitly passed to this param_group.

This PR is an attempt to avoid doing that and infer the scope based on the parent param's param_group.



