### PR TITLE
Add support for namespaced controllers with the same name (response validation)

### DIFF
--- a/lib/apipie/apipie_module.rb
+++ b/lib/apipie/apipie_module.rb
@@ -18,10 +18,10 @@ module Apipie
     app.to_swagger_json(version, resource_name, method_name, lang, clear_warnings)
   end
 
-  def self.json_schema_for_method_response(controller_name, method_name, return_code, allow_nulls)
+  def self.json_schema_for_method_response(controller, method_name, return_code, allow_nulls)
     # note: this does not support versions (only the default version is queried)!
     version ||= Apipie.configuration.default_version
-    app.json_schema_for_method_response(version, controller_name, method_name, return_code, allow_nulls)
+    app.json_schema_for_method_response(version, controller, method_name, return_code, allow_nulls)
   end
 
   def self.json_schema_for_self_describing_class(cls, allow_nulls=true)

--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -258,9 +258,9 @@ module Apipie
       @recorded_examples = nil
     end
 
-    def json_schema_for_method_response(version, controller_name, method_name, return_code, allow_nulls)
-      method = @resource_descriptions[version][controller_name].method_description(method_name)
-      raise NoDocumentedMethod.new(controller_name, method_name) if method.nil?
+    def json_schema_for_method_response(version, controller, method_name, return_code, allow_nulls)
+      method = @resource_descriptions[version][get_resource_name(controller)].method_description(method_name)
+      raise NoDocumentedMethod.new(controller.controller_name, method_name) if method.nil?
       @swagger_generator.json_schema_for_method_response(method, return_code, allow_nulls)
     end
 

--- a/lib/apipie/rspec/response_validation_helper.rb
+++ b/lib/apipie/rspec/response_validation_helper.rb
@@ -89,7 +89,7 @@ class ActionController::Base
     # this method is injected into ActionController::Base in order to
     # get access to the names of the current controller, current action, as well as to the response
     def schema_validation_errors_for_response
-      unprocessed_schema = Apipie::json_schema_for_method_response(controller_name, action_name, response.code, true)
+      unprocessed_schema = Apipie::json_schema_for_method_response(self.class, action_name, response.code, true)
 
       if unprocessed_schema.nil?
         err = "no schema defined for #{controller_name}##{action_name}[#{response.code}]"


### PR DESCRIPTION
When you have two controllers with the same name, the response validation will confuse the two due to use of `controller_name`.
This passes the controller class in instead so namespacing information can be retained.

example situation:
```
class FooController; end

module Bar
  class FooController; end
end
```
