### PR TITLE
ruby 3.0: fixes the dreaded 'wrong number of arguments (given 1, expected 0)' error.

### DIFF
--- a/lib/apipie/extractor/recorder.rb
+++ b/lib/apipie/extractor/recorder.rb
@@ -150,8 +150,8 @@ module Apipie
       end
 
       module FunctionalTestRecording
-        def process(*args) # action, parameters = nil, session = nil, flash = nil, http_method = 'GET')
-          ret = super(*args)
+        def process(*, **) # action, parameters = nil, session = nil, flash = nil, http_method = 'GET')
+          ret = super
           if Apipie.configuration.record
             Apipie::Extractor.call_recorder.analyze_functional_test(self)
             Apipie::Extractor.call_finished


### PR DESCRIPTION
by being less explicit in the super call, ie using just super and not super().

Also, line up the parameter signature with rails 6.0+.

In particular this stack track:

```      wrong number of arguments (given 1, expected 0)
     # ./vendor/bundle/ruby/3.0.0/gems/apipie-rails-0.5.19/lib/apipie/extractor/recorder.rb:153:in `process'
     # ./vendor/bundle/ruby/3.0.0/gems/rails-controller-testing-1.0.5/lib/rails/controller/testing/template_assertions.rb:62:in `process'
 ```
see here for details, if you care.
  https://stackoverflow.com/questions/31816149/difference-between-calling-super-and-calling-super