### PR TITLE
Fix 'Method foo.en not found for resource bar' errors with no languages set

### DIFF
--- a/app/controllers/apipie/apipies_controller.rb
+++ b/app/controllers/apipie/apipies_controller.rb
@@ -100,7 +100,7 @@ module Apipie
       [:resource, :method, :version].each do |par|
         if params[par]
           splitted = params[par].split('.')
-          if splitted.length > 1 && Apipie.configuration.languages.include?(splitted.last)
+          if splitted.length > 1 && (Apipie.configuration.languages.include?(splitted.last) || Apipie.configuration.default_locale == splitted.last)
             lang = splitted.last
             params[par].sub!(".#{lang}", '')
           end

--- a/spec/controllers/apipies_controller_spec.rb
+++ b/spec/controllers/apipies_controller_spec.rb
@@ -47,6 +47,31 @@ describe Apipie::ApipiesController do
 
       assert_response :not_found
     end
+
+    it "succeeds on method details with a supported language" do
+      allow(Apipie.configuration).to receive(:languages).and_return(%w[en es])
+
+      get :index, :params => { :version => "2.0", :resource => "architectures", :method => "index.es" }
+
+      assert_response :success
+    end
+
+    it "succeeds on method details with the default language" do
+      allow(Apipie.configuration).to receive(:default_locale).and_return("en")
+      allow(Apipie.configuration).to receive(:languages).and_return([])
+
+      get :index, :params => { :version => "2.0", :resource => "architectures", :method => "index.en" }
+
+      assert_response :success
+    end
+
+    it "returns not_found on a method with an unsupported language" do
+      allow(Apipie.configuration).to receive(:languages).and_return(%w[en es])
+
+      get :index, :params => { :version => "2.0", :resource => "architectures", :method => "index.jp" }
+
+      assert_response :not_found
+    end
   end
 
   describe "reload_controllers" do


### PR DESCRIPTION
The default configuration has `default_locale = 'en'` but `languages = []`, so the check below fails. There's probably a cleaner way, but this logic matches that in `lib/tasks/apipie.rake` that treats the total set of languages to be `languages + default_local`.

#565 is at least one of the bug reports related to this.