### PR TITLE
Replace Rails with ActionView, -Pack and -Support

### DIFF
--- a/Gemfile.rails41
+++ b/Gemfile.rails41
@@ -2,6 +2,8 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'rails', '~> 4.1.0'
+gem 'actionpack', '~> 4.1.0'
+gem 'actionview', '~> 4.1.0'
+gem 'activesupport', '~> 4.1.0'
 gem 'mime-types', '~> 2.99.3'
 gem 'test_engine', path: 'spec/dummy/components/test_engine', group: :test

--- a/Gemfile.rails42
+++ b/Gemfile.rails42
@@ -2,7 +2,9 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'rails', '~> 4.2.5'
+gem 'actionpack', ~> '4.2.0'
+gem 'actionview', ~> '4.2.0'
+gem 'activesupport', ~> '4.2.0'
 gem 'mime-types', '~> 2.99.3'
 gem 'sqlite3', '~> 1.3.6'
 

--- a/Gemfile.rails50
+++ b/Gemfile.rails50
@@ -2,7 +2,9 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'rails', '~> 5.0.0'
+gem 'actionpack', '~> 5.0.0'
+gem 'actionview', '~> 5.0.0'
+gem 'activesupport', '~> 5.0.0'
 gem 'mime-types', '~> 2.99.3'
 gem 'rails-controller-testing'
 

--- a/Gemfile.rails51
+++ b/Gemfile.rails51
@@ -2,7 +2,9 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'rails', '~> 5.1.0.rc1'
+gem 'actionpack', '~> 5.1.0'
+gem 'actionview', '~> 5.1.0'
+gem 'activesupport', '~> 5.1.0'
 gem 'mime-types', '~> 2.99.3'
 gem 'rails-controller-testing'
 

--- a/Gemfile.rails60
+++ b/Gemfile.rails60
@@ -2,7 +2,9 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'rails', '~> 6.0.2'
+gem 'actionpack', , '~> 6.0.2'
+gem 'actionview', , '~> 6.0.2'
+gem 'activesupport', '~> 6.0.2'
 gem 'mime-types', '~> 2.99.3'
 gem 'rails-controller-testing'
 gem 'rspec-rails', '4.0.0.beta3'

--- a/Gemfile.rails61
+++ b/Gemfile.rails61
@@ -2,7 +2,10 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'rails', '~> 6.1.1'
+gem 'actionpack', '~> 6.1.1'
+gem 'actionview', '~> 6.1.1'
+gem 'activesupport', '~> 6.1.1'
+
 gem 'mime-types', '~> 2.99.3'
 gem 'rails-controller-testing'
 gem 'rspec-rails', '~> 4.0.2'

--- a/apipie-rails.gemspec
+++ b/apipie-rails.gemspec
@@ -16,7 +16,11 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_dependency "rails", ">= 4.1"
+  s.add_dependency "actionview"
+  s.add_dependency "actionpack"
+  s.add_dependency "activesupport"
+
+  s.add_development_dependency "rails", ">= 4.1"
   s.add_development_dependency "rspec-rails", "~> 3.0"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "minitest"


### PR DESCRIPTION
This PR reduces the required and thus installed gems to the only required ones on apps using apipie-rails, as also mentioned in #701.
I am looking for feedback regarding this.
Tests are passing (at least with ruby 2.7.4).

Cheers, Erik