### PR TITLE
Fix schema generation for param descriptions using the array validator in option

### DIFF
--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -476,6 +476,9 @@ module Apipie
 
       if swagger_def[:type] == "array"
         swagger_def[:items] = {type: "string"}
+        enum = param_desc.options.fetch(:in, [])
+
+        swagger_def[:items][:enum] = enum if enum.any?
       end
 
       if swagger_def[:type] == "enum"
@@ -504,7 +507,8 @@ module Apipie
       end
 
       if !in_schema
-        swagger_def[:in] = param_desc.options.fetch(:in, @default_value_for_param_in)
+        # the "name" and "in" keys can only be set on root parameters (non-nested)
+        swagger_def[:in] = @default_value_for_param_in if name.present?
         swagger_def[:required] = param_desc.required if param_desc.required
       end
 

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -274,6 +274,12 @@ class UsersController < ApplicationController
     render :plain => 'nothing to see here'
   end
 
+  api :GET, '/users/in_departments', 'show users from specific departments'
+  param :departments, Array, in: ["finance", "operations", "sales", "marketing", "HR"], default_value: ['sales']
+  def get_in_departments
+    render :plain => 'nothing to see here'
+  end
+
   api :GET, '/users/desc_from_file', 'desc from file'
   document 'users/desc_from_file.md'
   def desc_from_file

--- a/spec/lib/swagger/rake_swagger_spec.rb
+++ b/spec/lib/swagger/rake_swagger_spec.rb
@@ -51,6 +51,17 @@ describe 'rake tasks' do
       expect(param[field]).to eq(value)
     end
 
+    def expect_array_param_def(http_method, path, param_name, value)
+      params = apidoc_swagger["paths"][path][http_method]["parameters"]
+      param = params.select { |p| p if p["name"] == param_name }[0]
+
+      expect(param['type']).to eq('array')
+      expect(param['items']).to eq(
+        'type' => 'string',
+        'enum' => value
+      )
+    end
+
     def expect_tags_def(http_method, path, value)
       params = apidoc_swagger["paths"][path][http_method]["tags"]
       expect(params).to eq(value)
@@ -117,6 +128,10 @@ describe 'rake tasks' do
         expect_param_def("put", "/users/{id}", "oauth", "in", "formData")
         expect_param_def("get", "/users/by_department", "department", "in", "query")
         expect_param_def("get", "/users/by_department", "department", "enum",
+                         ["finance", "operations", "sales", "marketing", "HR"])
+
+        expect_param_def("get", "/users/in_departments", "departments", "in", "query")
+        expect_array_param_def("get", "/users/in_departments", "departments",
                          ["finance", "operations", "sales", "marketing", "HR"])
 
         expect_tags_def("get", "/twitter_example/{id}/followers", %w[twitter_example following index search])


### PR DESCRIPTION
apipie now generates a valid swagger schema for param descriptions using the array validator `in` option

closes #731 