### PR TITLE
allow_blank does not work

### DIFF
--- a/lib/apipie/param_description.rb
+++ b/lib/apipie/param_description.rb
@@ -117,7 +117,7 @@ module Apipie
       return true if @allow_nil && value.nil?
       return true if @allow_blank && value.blank?
       value = normalized_value(value)
-      if (!@allow_nil && value.nil?) || !@validator.valid?(value)
+      if (!@allow_nil && value.nil?) || (!@allow_blank && value.blank?) || !@validator.valid?(value)
         error = @validator.error
         error = ParamError.new(error) unless error.is_a? StandardError
         raise error


### PR DESCRIPTION
Current code only checks when allow_blank is true, it doesn't check if allow_blank is false.

If an attribute allows String, but doesn't want to allow empty string, allow_blank doesn't work at all.





