### PR TITLE
ArgumentError (invalid byte sequence in UTF-8) #736

### DIFF
--- a/lib/apipie/static_dispatcher.rb
+++ b/lib/apipie/static_dispatcher.rb
@@ -9,7 +9,9 @@ module Apipie
 
     def match?(path)
       # Replace all null bytes
-      path = ::Rack::Utils.unescape(path || '').gsub(/\x0/, '')
+      path = ::Rack::Utils.unescape(path || '')
+                          .encode(Encoding::UTF_8, invalid: :replace, replace: '')
+                          .gsub(/\x0/, '')
 
       full_path = path.empty? ? @root : File.join(@root, path)
       paths = "#{full_path}#{ext}"

--- a/spec/lib/file_handler_spec.rb
+++ b/spec/lib/file_handler_spec.rb
@@ -14,5 +14,12 @@ describe Apipie::FileHandler do
       it { expect(file_handler.match? path).to be_falsy }
       it { expect { file_handler.match? path }.to_not raise_error }
     end
+
+    context 'when the path contans an invalid byte sequence in UTF-8' do
+      let(:path) { "%B6" }
+
+      it { expect(file_handler.match? path).to be_falsy }
+      it { expect { file_handler.match? path }.to_not raise_error }
+    end
   end
 end


### PR DESCRIPTION
https://github.com/Apipie/apipie-rails/issues/736 ArgumentError (invalid byte sequence in UTF-8). Remove invalid characters when parsing the file handler path.