### PR TITLE
Update boolean handling of false

### DIFF
--- a/lib/apipie/param_description.rb
+++ b/lib/apipie/param_description.rb
@@ -117,7 +117,7 @@ module Apipie
       return true if @allow_nil && value.nil?
       return true if @allow_blank && value.blank?
       value = normalized_value(value)
-      if (!@allow_nil && value.nil?) || (!@allow_blank && value.blank?) || !@validator.valid?(value)
+      if (!@allow_nil && value.nil?) || (!@allow_blank && (!@validator.is_a?(Validator::BooleanValidator) && value.blank?)) || !@validator.valid?(value)
         error = @validator.error
         error = ParamError.new(error) unless error.is_a? StandardError
         raise error

--- a/spec/lib/param_description_spec.rb
+++ b/spec/lib/param_description_spec.rb
@@ -118,6 +118,10 @@ describe Apipie::ParamDescription do
       it "should not throw an exception when passed false" do
         expect { Apipie::ParamDescription.new(method_desc, :param, :boolean).validate(false) }.to_not raise_error
       end
+
+      it "should throw an exception when passed an empty value" do
+        expect { Apipie::ParamDescription.new(method_desc, :param, :boolean).validate('') }.to raise_error(Apipie::ParamInvalid)
+      end
     end
 
     context 'when the parameter is a string' do

--- a/spec/lib/param_description_spec.rb
+++ b/spec/lib/param_description_spec.rb
@@ -113,6 +113,14 @@ describe Apipie::ParamDescription do
 
   end
 
+  describe 'validate' do
+    context 'when the parameter is a boolean' do
+      it "should not throw an exception when passed false" do
+        expect { Apipie::ParamDescription.new(method_desc, :param, :boolean).validate(false) }.to_not raise_error(Apipie::ParamInvalid, /^Invalid parameter 'param' value nil/)
+      end
+    end
+  end
+
   describe "concern substitution" do
 
     let(:concern_dsl_data) { dsl_data.merge(:from_concern => true) }

--- a/spec/lib/param_description_spec.rb
+++ b/spec/lib/param_description_spec.rb
@@ -116,7 +116,13 @@ describe Apipie::ParamDescription do
   describe 'validate' do
     context 'when the parameter is a boolean' do
       it "should not throw an exception when passed false" do
-        expect { Apipie::ParamDescription.new(method_desc, :param, :boolean).validate(false) }.to_not raise_error(Apipie::ParamInvalid, /^Invalid parameter 'param' value nil/)
+        expect { Apipie::ParamDescription.new(method_desc, :param, :boolean).validate(false) }.to_not raise_error
+      end
+    end
+
+    context 'when the parameter is a string' do
+      it "should throw an exception when passed an empty value" do
+        expect { Apipie::ParamDescription.new(method_desc, :param, String).validate('') }.to raise_error(Apipie::ParamInvalid)
       end
     end
   end


### PR DESCRIPTION
Expand the logic around blank value checking.

If `@allow_blank` is false, make sure it's not a BooleanValidator before looking for `value.blank?` as `false` is a valid boolean response, but
```ruby
false.blank? # => true
```
Create a test to replicate what we are seeing in use, when passing the value of `false` to a `:boolean` parameter (as opposed to `"false"` which is parsed as a string)