### PR TITLE
Fix ruby2_keywords-related warning

### DIFF
--- a/lib/apipie/extractor/recorder.rb
+++ b/lib/apipie/extractor/recorder.rb
@@ -150,7 +150,7 @@ module Apipie
       end
 
       module FunctionalTestRecording
-        def process(*, **) # action, parameters = nil, session = nil, flash = nil, http_method = 'GET')
+        def process(*) # action, parameters = nil, session = nil, flash = nil, http_method = 'GET')
           ret = super
           if Apipie.configuration.record
             Apipie::Extractor.call_recorder.analyze_functional_test(self)


### PR DESCRIPTION
Fixes https://github.com/Apipie/apipie-rails/issues/753

Context: https://github.com/Apipie/apipie-rails/pull/716#discussion_r852005248