### PR TITLE
[Bugfix] API Docs were showing up in Korean by default

### DIFF
--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1,4 +1,4 @@
-en:
+ko:
   apipie:
     resources: 리소스
     resource: 리소스


### PR DESCRIPTION
Fixes https://github.com/Apipie/apipie-rails/issues/755

It seems that since the Korean translations were added, the first key on the YAML file was `en`, which was recently causing the problem.