### PR TITLE
Allow custom validators to opt out of allow_blank behavior

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1385,6 +1385,15 @@ options
 block
   Block converted into Proc, use it as you desire. In this example nil.
 
+If your validator includes valid values that respond true to `.blank?`, you
+should also define:
+
+.. code:: ruby
+   def ignore_allow_blank?
+     true
+   end
+
+so that the validation does not fail for valid values.
 
 ============
  Versioning

--- a/lib/apipie/param_description.rb
+++ b/lib/apipie/param_description.rb
@@ -125,7 +125,7 @@ module Apipie
     end
 
     def blank_forbidden?
-      !Apipie.configuration.ignore_allow_blank_false && !allow_blank && !validator.is_a?(Validator::BooleanValidator)
+      !Apipie.configuration.ignore_allow_blank_false && !allow_blank && !validator.ignore_allow_blank?
     end
 
     def process_value(value)

--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -80,6 +80,10 @@ module Apipie
         'string'
       end
 
+      def ignore_allow_blank?
+        false
+      end
+
       def merge_with(other_validator)
         return self if self == other_validator
         raise NotImplementedError, "Don't know how to merge #{self.inspect} with #{other_validator.inspect}"
@@ -476,6 +480,10 @@ module Apipie
       def description
         string = %w(true false 1 0).map { |value| format_description_value(value) }.join(', ')
         "Must be one of: #{string}."
+      end
+
+      def ignore_allow_blank?
+        true
       end
     end
 

--- a/spec/lib/param_description_spec.rb
+++ b/spec/lib/param_description_spec.rb
@@ -157,8 +157,26 @@ describe Apipie::ParamDescription do
         expect { Apipie::ParamDescription.new(method_desc, :param, :boolean).validate(false) }.to_not raise_error
       end
 
+      it "should still not throw an exception when passed false with explicit allow_blank: false" do
+        expect { Apipie::ParamDescription.new(method_desc, :param, :boolean, allow_blank: false).validate(false) }.to_not raise_error
+      end
+
       it "should throw an exception when passed an empty value" do
         expect { Apipie::ParamDescription.new(method_desc, :param, :boolean).validate('') }.to raise_error(Apipie::ParamInvalid)
+      end
+    end
+
+    context "when the parameter is a custom type with ignore_allow_blank? returning true" do
+      it "should not throw an exception when passed a blank but valid value" do
+        expect { Apipie::ParamDescription.new(method_desc, :param, :custom_bool).validate(false) }.to_not raise_error
+      end
+
+      it "should still not throw an exception when passed false with explicit allow_blank: false" do
+        expect { Apipie::ParamDescription.new(method_desc, :param, :custom_bool, allow_blank: false).validate(false) }.to_not raise_error
+      end
+
+      it "should throw an exception when passed an invalid but blank value" do
+        expect { Apipie::ParamDescription.new(method_desc, :param, :custom_bool).validate("") }.to raise_error(Apipie::ParamInvalid)
       end
     end
 

--- a/spec/support/custom_bool_validator.rb
+++ b/spec/support/custom_bool_validator.rb
@@ -1,0 +1,17 @@
+class CustomBoolValidator < Apipie::Validator::BaseValidator
+  def validate(value)
+    value.in?([true, false])
+  end
+
+  def self.build(param_description, argument, options, block)
+    new(param_description) if argument == :custom_bool
+  end
+
+  def description
+    "Must be a boolean."
+  end
+
+  def ignore_allow_blank?
+    true
+  end
+end


### PR DESCRIPTION
My app has a custom boolean validator that looks like this:

```ruby
class BoolValidator < Apipie::Validator::BaseValidator
  def validate(value)
    value.in?([true, false])
  end

  def self.build(param_description, argument, options, block)
    new(param_description) if argument == :bool
  end

  def description
    "Must be a boolean."
  end
end
```

But, this validator is failing when a `false` value is passed via the API because `false.blank?` is true and `allow_blank: false` is the default behavior for field definitions. There is a hard-coded [carve-out for BooleanValidator](https://github.com/Apipie/apipie-rails/blob/master/lib/apipie/param_description.rb#L128) so that this does not occur, but there is no way to replicate the same behavior in custom validators.

This PR adds a method to `BaseValidator` called `ignore_allow_blank?` and updates the blank validation logic so that it no longer has a hard-coded check for `BooleanValidator` and now just checks the validator's value for `ignore_allow_blank?`. The logic for `BooleanValidator` is preserved, and custom validators can now also achieve the same behavior.