### PR TITLE
Add contributing instructions to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1872,6 +1872,20 @@ provided it uses Apipie as a backend.
 
 And if you write one on your own, don't hesitate to share it with us!
 
+====================
+ Contributing
+====================
+
+Install dependencies:
+
+.. code:: shell
+   > bundle install --gemfile gemfiles/Gemfile.rails61
+
+Then run the tests:
+
+.. code:: shell
+   > export BUNDLE_GEMFILE='gemfiles/Gemfile.rails61'; bundle exec rspec
+
 
 ====================
  Disqus Integration

--- a/README.rst
+++ b/README.rst
@@ -1876,16 +1876,16 @@ And if you write one on your own, don't hesitate to share it with us!
  Contributing
 ====================
 
-Install dependencies:
+Since this gem does not have a Gemfile, you need to specify it in your shel with:
 
 .. code:: shell
-   > bundle install --gemfile gemfiles/Gemfile.rails61
+   BUNDLE_GEMFILE='gemfiles/Gemfile.rails61'
 
-Then run the tests:
+Then, you can install dependencies and run the test suite:
 
 .. code:: shell
-   > export BUNDLE_GEMFILE='gemfiles/Gemfile.rails61'; bundle exec rspec
-
+   > bundle install
+   > bundle exec rspec
 
 ====================
  Disqus Integration

--- a/README.rst
+++ b/README.rst
@@ -1876,7 +1876,7 @@ And if you write one on your own, don't hesitate to share it with us!
  Contributing
 ====================
 
-Since this gem does not have a Gemfile, you need to specify it in your shel with:
+Since this gem does not have a Gemfile, you need to specify it in your shell with:
 
 .. code:: shell
    BUNDLE_GEMFILE='gemfiles/Gemfile.rails61'


### PR DESCRIPTION
I had some difficulty getting this project running since there isn't a Gemfile in the project, and I didn't see any contributing instructions. This PR adds some simple instructions for getting the test suite running to the Readme.

I do wonder why the Gemfile was removed and if the proper solution would be to add it back to the project.