### PR TITLE
Fix readme code block

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1389,6 +1389,7 @@ If your validator includes valid values that respond true to `.blank?`, you
 should also define:
 
 .. code:: ruby
+
    def ignore_allow_blank?
      true
    end


### PR DESCRIPTION
The code block in the readme documenting the `ignore_allow_blank?` functionality for custom validators that was added in https://github.com/Apipie/apipie-rails/pull/762 was not displaying. This fixes the RST syntax issue so it displays.