### PR TITLE
Adds expected_type to IntegerValidator example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1368,6 +1368,10 @@ So we create apipie_validators.rb initializer with this content:
      def description
        "Must be #{@type}."
      end
+
+     def expected_type
+       'numeric'
+     end
    end
 
 Parameters of the build method:


### PR DESCRIPTION
Otherwise, the generated docs.json outputs the field as a `string` and not a `number`