### PR TITLE
Add expected_type to DecimalValidator

### DIFF
--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -432,6 +432,10 @@ module Apipie
         "Must be a decimal number."
       end
 
+      def expected_type
+        'numeric'
+      end
+
       def self.validate(value)
         value.to_s =~ /\A^[-+]?[0-9]+([,.][0-9]+)?\Z$/
       end


### PR DESCRIPTION
Generated docs.json outputs the field as a `string` and not a `number`