### PR TITLE
Change output folder to `spec/dummy/tmp/`

### DIFF
--- a/spec/lib/extractor/writer_spec.rb
+++ b/spec/lib/extractor/writer_spec.rb
@@ -59,16 +59,16 @@ describe Apipie::Extractor::Writer do
     }
   }
 
-  context 'with doc_path overriden in configuration' do
+  context 'with doc_path overridden in configuration' do
     around(:each) do |example|
       standard_path = Apipie.configuration.doc_path
-      Apipie.configuration.doc_path = 'user_specified_doc_path'
+      Apipie.configuration.doc_path = 'tmp/user_specified_doc_path'
       example.run
       Apipie.configuration.doc_path = standard_path
     end
 
     it 'should use the doc_path specified in configuration' do
-      expect(writer_class.examples_file).to eql(File.join(Rails.root, 'user_specified_doc_path', 'apipie_examples.json'))
+      expect(writer_class.examples_file).to eql(File.join(Rails.root, 'tmp', 'user_specified_doc_path', 'apipie_examples.json'))
     end
   end
 

--- a/spec/lib/rake_spec.rb
+++ b/spec/lib/rake_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'rake tasks' do
   include_context "rake"
 
-  let(:doc_path)  { "user_specified_doc_path" }
+  let(:doc_path)  { 'tmp/user_specified_doc_path' }
 
   before do
     Apipie.configuration.doc_path = doc_path

--- a/spec/lib/swagger/rake_swagger_spec.rb
+++ b/spec/lib/swagger/rake_swagger_spec.rb
@@ -8,7 +8,7 @@ require File.expand_path('../../dummy/app/controllers/pets_controller.rb', __dir
 describe 'rake tasks' do
   include_context "rake"
 
-  let(:doc_path)  { "user_specified_doc_path" }
+  let(:doc_path)  { 'tmp/user_specified_doc_path' }
 
   before do
     Apipie.configuration.doc_path = doc_path


### PR DESCRIPTION
#### Why
`spec/dummy/` is not version controlled. 
Using a not tracked folder will avoid test generated files being indexed by an IDE or git.

#### How
Changes the output folder to `spec/dummy/tmp/`