### PR TITLE
Fix #446 Fixing full_description translation

### DIFF
--- a/lib/apipie/error_description.rb
+++ b/lib/apipie/error_description.rb
@@ -34,7 +34,7 @@ module Apipie
     def to_json(lang)
       {
         :code => code,
-        :description => Apipe.app.translate(description, lang),
+        :description => Apipie.app.translate(description, lang),
         :metadata => metadata
       }
     end

--- a/lib/apipie/error_description.rb
+++ b/lib/apipie/error_description.rb
@@ -31,10 +31,10 @@ module Apipie
       end
     end
 
-    def to_json
+    def to_json(lang)
       {
         :code => code,
-        :description => description,
+        :description => Apipe.app.translate(description, lang),
         :metadata => metadata
       }
     end

--- a/lib/apipie/method_description.rb
+++ b/lib/apipie/method_description.rb
@@ -167,7 +167,7 @@ module Apipie
         :apis => method_apis_to_json(lang),
         :formats => formats,
         :full_description => Apipie.app.translate(@full_description, lang),
-        :errors => errors.map(&:to_json),
+        :errors => errors.map{ |error| error.to_json(lang) }.flatten,
         :params => params_ordered.map{ |param| param.to_json(lang) }.flatten,
         :returns => @returns.map{ |return_item| return_item.to_json(lang) }.flatten,
         :examples => @examples,

--- a/lib/apipie/resource_description.rb
+++ b/lib/apipie/resource_description.rb
@@ -35,7 +35,7 @@ module Apipie
 
     def update_from_dsl_data(dsl_data)
       @_name = dsl_data[:resource_name] if dsl_data[:resource_name]
-      @_full_description = Apipie.markup_to_html(dsl_data[:description])
+      @_full_description = dsl_data[:description]
       @_short_description = dsl_data[:short_description]
       @_path = dsl_data[:path] || ""
       @_formats = dsl_data[:formats]
@@ -110,7 +110,7 @@ module Apipie
         :api_url => api_url,
         :name => @_name,
         :short_description => Apipie.app.translate(@_short_description, lang),
-        :full_description => Apipie.app.translate(@_full_description, lang),
+        :full_description => Apipie.markup_to_html(Apipie.app.translate(@_full_description, lang)),
         :version => _version,
         :formats => @_formats,
         :metadata => @_metadata,

--- a/lib/apipie/response_description.rb
+++ b/lib/apipie/response_description.rb
@@ -121,7 +121,7 @@ module Apipie
     def to_json(lang=nil)
       {
           :code => code,
-          :description => description,
+          :description => Apipie.app.translate(description, lang),
           :is_array => is_array?,
           :returns_object => params_ordered.map{ |param| param.to_json(lang).tap{|h| h.delete(:validations) }}.flatten,
           :additional_properties => additional_properties,


### PR DESCRIPTION
Full description cannot be translated as key was converted to HTML before translation. I changed that in this PR.