### PR TITLE
Create test cache files under a not version controlled directory

### DIFF
--- a/lib/apipie/resource_description.rb
+++ b/lib/apipie/resource_description.rb
@@ -7,7 +7,7 @@ module Apipie
   # path - relative path (/api/articles)
   # methods - array of keys to Apipie.method_descriptions (array of Apipie::MethodDescription)
   # name - human readable alias of resource (Articles)
-  # id - resouce name
+  # id - resource name
   # formats - acceptable request/response format types
   # headers - array of headers
   # deprecated - boolean indicating if resource is deprecated

--- a/spec/dummy/config/initializers/apipie.rb
+++ b/spec/dummy/config/initializers/apipie.rb
@@ -23,7 +23,7 @@ Apipie.configure do |config|
   #     rake apipie:cache
   #
   config.use_cache = Rails.env.production?
-  # config.cache_dir = File.join(Rails.root, "public", "apipie-cache") # optional
+  config.cache_dir = File.join(Rails.root, "tmp", "apipie-cache") # optional
 
   # set to enable/disable reloading controllers (and the documentation with it),
   # by default enabled in development

--- a/spec/lib/rake_spec.rb
+++ b/spec/lib/rake_spec.rb
@@ -49,9 +49,7 @@ describe 'rake tasks' do
   end
 
   describe 'apipie:cache' do
-    let(:cache_output) do
-      File.join(::Rails.root, 'public', 'apipie-cache')
-    end
+    let(:cache_output) { Apipie.configuration.cache_dir }
 
     let(:apidoc_html) do
       File.read("#{cache_output}.html")


### PR DESCRIPTION
### Why
Similar to https://github.com/Apipie/apipie-rails/pull/804
`public/apipie-cache` is version controlled.
Using a not tracked folder will avoid test generated files being indexed by an IDE or git.

### How
Uncomments and assigns a not version controlled directory to `config.cache_dir`