### PR TITLE
Enable Style/HashSyntax Ruby 1.9

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,3 +35,6 @@ Naming/PredicateName:
 
 Style/NumericPredicate:
   Enabled: false
+
+Style/HashSyntax:
+  EnforcedStyle: ruby19


### PR DESCRIPTION
For consistency reasons we standardize to Ruby 1.9 style of Hash syntax

https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashSyntax

Example
{:a => 2}
{b: 1, :c => 2}

{a: 2, b: 1}
{:c => 2, 'd' => 2} # acceptable since 'd' isn't a symbol
{d: 1, 'e' => 2} # technically not forbidden