### PR TITLE
swagger missing i18n

### DIFF
--- a/lib/apipie/method_description.rb
+++ b/lib/apipie/method_description.rb
@@ -10,8 +10,7 @@ module Apipie
       @from_concern = dsl_data[:from_concern]
       @apis = ApisService.new(resource, method, dsl_data).call
 
-      desc = dsl_data[:description] || ''
-      @full_description = Apipie.markup_to_html(desc)
+      @full_description = dsl_data[:description] || ''
 
       @errors = dsl_data[:errors].map do |args|
         Apipie::ErrorDescription.from_dsl_data(args)
@@ -166,7 +165,7 @@ module Apipie
         :name => @method,
         :apis => method_apis_to_json(lang),
         :formats => formats,
-        :full_description => Apipie.app.translate(@full_description, lang),
+        :full_description => Apipie.markup_to_html(Apipie.app.translate(@full_description, lang)),
         :errors => errors.map{ |error| error.to_json(lang) }.flatten,
         :params => params_ordered.map{ |param| param.to_json(lang) }.flatten,
         :returns => @returns.map{ |return_item| return_item.to_json(lang) }.flatten,

--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -267,7 +267,7 @@ module Apipie
             summary: Apipie.app.translate(api.short_description, @current_lang),
             parameters: swagger_params_array_for_method(ruby_method, api.path),
             responses: responses,
-            description: ruby_method.full_description
+            description: Apipie.app.translate(ruby_method.full_description, @current_lang)
         }
 
         if methods[method_key][:summary].nil?
@@ -392,7 +392,7 @@ module Apipie
 
       for response in method.returns
         swagger_response_block = {
-            description: response.description
+            description: Apipie.app.translate(response.description, @current_lang)
         }
 
         schema = response_schema(response)


### PR DESCRIPTION
Some fields had not i18n applied for swagger. At least this happened to method full description and method return description.
I also needed to apply the markup fix as in #808.