### PR TITLE
Allow action matcher strategy to be configured

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -982,6 +982,9 @@ reload_controllers
 api_controllers_matcher
   For reloading to work properly you need to specify where your API controllers are. Can be an array if multiple paths are needed
 
+api_action_matcher
+  Determines the strategy to identity the correct controller action. Needs to be a class that implements a `.call(controller)` method
+
 api_routes
   Set if your application uses a custom API router, different from the Rails
   default
@@ -1063,6 +1066,7 @@ Example:
      config.markup = Apipie::Markup::Markdown.new
      config.reload_controllers = Rails.env.development?
      config.api_controllers_matcher = File.join(Rails.root, "app", "controllers", "**","*.rb")
+     config.api_action_matcher = proc { |controller| controller.params[:action] }
      config.api_routes = Rails.application.routes
      config.app_info["1.0"] = "
        This is where you can inform user about your application and API

--- a/lib/apipie/configuration.rb
+++ b/lib/apipie/configuration.rb
@@ -27,6 +27,16 @@ module Apipie
     #   "#{Rails.root}/app/controllers/api/*.rb"
     attr_accessor :api_controllers_matcher
 
+    # An object that responds to a `.call(controller)` method responsible for
+    # matching the correct controller action
+    attr_reader :api_action_matcher
+
+    def api_action_matcher=(callable)
+      raise 'Must implement .call method' unless callable.respond_to?(:call)
+
+      @api_action_matcher = callable
+    end
+
     # set to true if you want to reload the controllers at each refresh of the
     # documentation. It requires +:api_controllers_matcher+ to be set to work
     # properly.
@@ -156,6 +166,7 @@ module Apipie
       @action_on_non_validated_keys = :raise
       @required_by_default = false
       @api_base_url = HashWithIndifferentAccess.new
+      @api_action_matcher = proc { |controller| controller.params[:action] }
       @doc_base_url = "/apipie"
       @layout = "apipie/apipie"
       @disqus_shortname = nil

--- a/lib/apipie/extractor/recorder.rb
+++ b/lib/apipie/extractor/recorder.rb
@@ -24,7 +24,7 @@ module Apipie
 
       def analyse_controller(controller)
         @controller = controller.class
-        @action = controller.params[:action]
+        @action = Apipie.configuration.api_action_matcher.call(controller)
       end
 
       def analyse_response(response)

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Apipie::Configuration' do
+  let(:configuration) { Apipie::Configuration.new }
+
+  describe '#api_action_matcher=' do
+    subject(:setter) { configuration.api_action_matcher = matcher }
+
+    let(:matcher) { proc { |_| :some_action } }
+
+    it { is_expected.to eq(matcher) }
+
+    context 'when matcher does not implement .call method' do
+      let(:matcher) { 'I do not implement .call' }
+
+      it 'raises and exception' do
+        expect { setter }.to raise_error('Must implement .call method')
+      end
+    end
+  end
+end

--- a/spec/lib/extractor/recorder_spec.rb
+++ b/spec/lib/extractor/recorder_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Apipie::Extractor::Recorder' do
+  let(:recorder) { Apipie::Extractor::Recorder.new }
+
+  describe '#analyse_controller' do
+    subject do
+      recorder.analyse_controller(controller)
+      recorder.record[:action]
+    end
+
+    let(:action) { :show }
+
+    let(:request) do
+      request = ActionDispatch::Request.new({})
+      request.request_parameters = { action: action }
+      request
+    end
+
+    let(:controller) do
+      controller = ActionController::Metal.new
+      controller.set_request!(request)
+      controller
+    end
+
+    it { is_expected.to eq(action) }
+
+    context 'when a api_action_matcher is configured' do
+      let(:matcher_action) { "#{action}_from_new_matcher" }
+
+      before do
+        Apipie.configuration.api_action_matcher = proc { |_| matcher_action }
+      end
+
+      it { is_expected.to eq(matcher_action) }
+    end
+  end
+end


### PR DESCRIPTION
## Why
Currently we use the `action` param from the `Request` object to identify the correct action  but there might some kind of logic, a method for example, that directs the request to a specific action. 

## How
Make the action matching strategy configurable by introducing `Apipie.configuration.api_action_matcher` that accepts a callable object.


<ins>Example</ins>

```ruby
class SomeMatchingStrategy
  self.call(controller)
     #... Matching logic
  end
end

Apipie.configuration.api_action_matcher = SomeMatchingStrategy

```
