### PR TITLE
Make html markup thread safe

### DIFF
--- a/lib/apipie/markup.rb
+++ b/lib/apipie/markup.rb
@@ -4,6 +4,11 @@ module Apipie
 
     class RDoc
 
+      def initialize
+        require 'rdoc'
+        require 'rdoc/markup/to_html'
+      end
+
       def to_html(text)
         rdoc.convert(text)
       end
@@ -11,14 +16,10 @@ module Apipie
       private
 
       def rdoc
-        @rdoc ||= begin
-          require 'rdoc'
-          require 'rdoc/markup/to_html'
-          if Gem::Version.new(::RDoc::VERSION) < Gem::Version.new('4.0.0')
-            ::RDoc::Markup::ToHtml.new()
-          else
-            ::RDoc::Markup::ToHtml.new(::RDoc::Options.new)
-          end
+        if Gem::Version.new(::RDoc::VERSION) < Gem::Version.new('4.0.0')
+          ::RDoc::Markup::ToHtml.new()
+        else
+          ::RDoc::Markup::ToHtml.new(::RDoc::Options.new)
         end
       end
     end


### PR DESCRIPTION
Previously we were using a shared instance of Rdoc::Markup::ToHtml. This instance changes its internal state when processing markups, which could lead to issues when generating docs concurrently.