### PR TITLE
Run Rubocop when opening PR

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,20 @@
+name: RuboCop
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: gemfiles/Gemfile.rails70
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Ruby 2.7
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+
+      - name: Run rubocop
+        run: bundle exec rubocop --config .rubocop.yml

--- a/apipie-rails.gemspec
+++ b/apipie-rails.gemspec
@@ -28,6 +28,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-rails", "~> 3.0"
   s.add_development_dependency "rake"
   s.add_development_dependency 'rubocop_challenger'
+  s.add_development_dependency 'rubocop-rails'
+  s.add_development_dependency 'rubocop-rspec'
+  s.add_development_dependency 'rubocop-performance'
   s.add_development_dependency "simplecov"
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
We could avoid having Rubocop violations merged into master if we run Robocop during PR 

WDYT 🤔 ?

https://github.com/Apipie/apipie-rails/pull/825 & https://github.com/Apipie/apipie-rails/pull/827 will propably need to be merged first.