### PR TITLE
Fix Lint/NonDeterministicRequireOrder error

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,7 +55,7 @@ end
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
-Dir[File.expand_path('support/**/*.rb', __dir__)].each {|f| require f}
+Dir[File.expand_path('support/**/*.rb', __dir__)].sort.each {|f| require f}
 
 RSpec.configure do |config|
 


### PR DESCRIPTION
Fixes `Lint/NonDeterministicRequireOrder` Rubocop violation