### PR TITLE
Fixed warnings due to uninitialized instance variable

### DIFF
--- a/lib/apipie/dsl_definition.rb
+++ b/lib/apipie/dsl_definition.rb
@@ -344,10 +344,11 @@ module Apipie
       #
       def param(param_name, validator, desc_or_options = nil, options = {}, &block) #:doc:
         return unless Apipie.active_dsl?
+        current_param_group = defined?(@_current_param_group) && @_current_param_group
         _apipie_dsl_data[:params] << [param_name,
                                       validator,
                                       desc_or_options,
-                                      options.merge(:param_group => @_current_param_group),
+                                      options.merge(:param_group => current_param_group),
                                       block]
       end
 

--- a/lib/apipie/param_description.rb
+++ b/lib/apipie/param_description.rb
@@ -101,7 +101,7 @@ module Apipie
     end
 
     def from_concern?
-      method_description.from_concern? || @from_concern
+      method_description.from_concern? || (defined?(@from_concern) && @from_concern)
     end
 
     def normalized_value(value)


### PR DESCRIPTION
I have fixed following two warnings:

1. lib/apipie/param_description.rb:103: warning: instance variable @from_concern not initialized
2. lib/apipie/dsl_definition.rb:349: warning: instance variable @_current_param_group not initialized