### PR TITLE
Disables FrozenStringLiteralComment rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -119,3 +119,9 @@ Style/FrozenStringLiteralComment:
 Naming/BlockForwarding:
   EnforcedStyle: explicit
   BlockForwardingName: block
+
+Lint/MissingSuper:
+  Exclude:
+    - 'lib/apipie/errors.rb'
+    - 'lib/apipie/response_description_adapter.rb'
+    - 'lib/apipie/validator.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -113,6 +113,9 @@ Style/Documentation:
     - spec/lib/validators/array_validator_spec.rb
     - spec/dummy/**/*.rb
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 Naming/BlockForwarding:
   EnforcedStyle: explicit
   BlockForwardingName: block

--- a/lib/apipie/errors.rb
+++ b/lib/apipie/errors.rb
@@ -60,27 +60,13 @@ module Apipie
 
   class ResponseDoesNotMatchSwaggerSchema < Error
     def initialize(controller_name, method_name, response_code, error_messages, schema, returned_object)
-      @controller_name = controller_name
-      @method_name = method_name
-      @response_code = response_code
-      @error_messages = error_messages
-      @schema = schema
-      @returned_object = returned_object
-    end
-
-    def to_s
-      "Response does not match swagger schema (#{@controller_name}##{@method_name} #{@response_code}): #{@error_messages}\nSchema: #{JSON(@schema)}\nReturned object: #{@returned_object}"
+      super("Response does not match swagger schema (#{controller_name}##{method_name} #{response_code}): #{error_messages}\nSchema: #{JSON(schema)}\nReturned object: #{returned_object}")
     end
   end
 
   class NoDocumentedMethod < Error
     def initialize(controller_name, method_name)
-      @method_name = method_name
-      @controller_name = controller_name
-    end
-
-    def to_s
-      "There is no documented method #{@controller_name}##{@method_name}"
+      super("There is no documented method #{controller_name}##{method_name}")
     end
   end
 end

--- a/spec/lib/apipie/no_documented_method_spec.rb
+++ b/spec/lib/apipie/no_documented_method_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Apipie::NoDocumentedMethod do
+  let(:error) { described_class.new(controller_name, method_name) }
+  let(:controller_name) { 'UserController' }
+  let(:method_name) { 'index' }
+
+  describe '#to_s' do
+    subject { error.to_s }
+
+    let(:error_message) do
+      "There is no documented method #{controller_name}##{method_name}"
+    end
+
+    it { is_expected.to eq(error_message) }
+  end
+end

--- a/spec/lib/apipie/response_does_not_match_swagger_schema_spec.rb
+++ b/spec/lib/apipie/response_does_not_match_swagger_schema_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Apipie::ResponseDoesNotMatchSwaggerSchema do
+  let(:error) do
+    described_class.new(
+      controller_name,
+      method_name,
+      response_code,
+      error_messages,
+      schema,
+      returned_object
+    )
+  end
+
+  let(:controller_name) { 'UserController' }
+  let(:method_name) { 'index' }
+  let(:response_code) { 200 }
+  let(:error_messages) { [] }
+  let(:schema) { {} }
+  let(:returned_object) { {} }
+
+  describe '#to_s' do
+    subject { error.to_s }
+
+    let(:error_message) do
+      <<~HEREDOC.chomp
+        Response does not match swagger schema (#{controller_name}##{method_name} #{response_code}): #{error_messages}
+        Schema: #{JSON(schema)}
+        Returned object: #{returned_object}
+      HEREDOC
+    end
+
+    it { is_expected.to eq(error_message) }
+  end
+end


### PR DESCRIPTION

### Why
It does not seem to make a lot of sense to be enforced anymore ([Standard](https://github.com/testdouble/standard#why-arent-frozen_string_literal-true-magic-comments-enforced) has a good explanation) and since it's not used in the gem's codebase I think it can be disabled.

