### PR TITLE
Disables Style/IfUnlessModifier rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,6 +55,9 @@ Naming/PredicateName:
   AllowedMethods:
     - have_field?
 
+Style/IfUnlessModifier:
+  Enabled: false
+
 Style/NumericPredicate:
   Enabled: false
 


### PR DESCRIPTION
Having this rule enabled forces the modifier if statement to be used

So this

```ruby
if Apipie.configuration.swagger_api_host.present?
  @swagger[:host] = Apipie.configuration.swagger_api_host
end
```

should be changed to 

```ruby
@swagger[:host] = Apipie.configuration.swagger_api_host if Apipie.configuration.swagger_api_host.present?
```

resulting in longer, harder to read lines.

Since the use the regular if statement all over the gem's codebase we can disable this rule.