### PR TITLE
Disables Metrics/ParameterLists

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,6 +51,9 @@ Metrics/BlockLength:
     - lib/tasks/apipie.rake
     - lib/apipie/swagger_generator.rb
 
+Metrics/ParameterLists:
+  Enabled: false
+
 Naming/PredicateName:
   AllowedMethods:
     - have_field?


### PR DESCRIPTION
Although long parameters can be considered a code smell, in case of a [data transfer objects ](https://github.com/Apipie/apipie-rails/pull/816/files#diff-3926cca4c7fc6e45d5a46a2a0d7c9b20172fc231774be32a73cd362a1d81d231R5) makes sense if the parameters are more than 7