### PR TITLE
Separate nested resource name

### DIFF
--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -375,8 +375,18 @@ module Apipie
         @controller_to_resource_id[klass]
       elsif Apipie.configuration.namespaced_resources? && klass.respond_to?(:controller_path)
         return nil if klass == ActionController::Base
+
+        version_prefix = version_prefix(klass)
         path = klass.controller_path
-        path.gsub(version_prefix(klass), "").gsub("/", "-")
+
+        path =
+          if version_prefix == '/'
+            path
+          else
+            path.gsub(version_prefix, '')
+          end
+
+        path.gsub('/', '-')
       elsif klass.respond_to?(:controller_name)
         return nil if klass == ActionController::Base
         klass.controller_name

--- a/spec/lib/apipie/application_spec.rb
+++ b/spec/lib/apipie/application_spec.rb
@@ -16,36 +16,37 @@ describe Apipie::Application do
 
   end
 
-  describe "get_resource_name" do
-    subject {Apipie.get_resource_name(Api::V2::Nested::ArchitecturesController)}
+  describe '.get_resource_name' do
+    subject(:get_resource_name) do
+      Apipie.get_resource_name(Api::V2::Nested::ArchitecturesController)
+    end
+
+    let(:base_url) { '/some-api' }
+
+    before { allow(Apipie.app).to receive(:get_base_url).and_return(base_url) }
 
     context "with namespaced_resources enabled" do
       before { Apipie.configuration.namespaced_resources = true }
-      context "with a defined base url" do
+      after { Apipie.configuration.namespaced_resources = false }
 
-        it "should not overwrite the parent resource" do
-          is_expected.not_to eq(Apipie.get_resource_name(Api::V2::ArchitecturesController))
-        end
-
+      it "returns the namespaces" do
+        is_expected.to eq('api-v2-nested-architectures')
       end
 
       context "with an undefined base url" do
-        before {allow(Apipie.app).to receive(:get_base_url).and_return(nil)}
+        let(:base_url) { nil }
 
         it "should not raise an error" do
-          expect { Apipie.get_resource_name(Api::V2::ArchitecturesController) }.
-            not_to raise_error
+          expect { get_resource_name }.not_to raise_error
         end
       end
-
-      after { Apipie.configuration.namespaced_resources = false }
     end
 
-    context "with namespaced_resources enabled" do
+    context "with namespaced_resources disabled" do
       before { Apipie.configuration.namespaced_resources = false }
 
-      it "should overwrite the the parent" do
-        is_expected.to eq(Apipie.get_resource_name(Api::V2::ArchitecturesController))
+      it "returns the controller name" do
+        is_expected.to eq('architectures')
       end
     end
   end

--- a/spec/lib/apipie/resource_description_spec.rb
+++ b/spec/lib/apipie/resource_description_spec.rb
@@ -1,48 +1,72 @@
 require "spec_helper"
 
 describe Apipie::ResourceDescription do
-
-  let(:dsl_data) { ActionController::Base.send(:_apipie_dsl_data_init) }
-
-  describe "metadata" do
-
-    it "should return nil when no metadata is provided" do
-      resource = Apipie::ResourceDescription.new(ApplicationController, "dummy", dsl_data)
-      expect(resource.to_json[:metadata]).to eq(nil)
-    end
-
-    it "should return the metadata" do
-      meta = {
-        :lenght => 32,
-        :weight => '830g'
-      }
-      resource = Apipie::ResourceDescription.new(ApplicationController, "dummy", dsl_data.update(:meta => meta))
-      expect(resource.to_json[:metadata]).to eq(meta)
-    end
-
+  let(:resource_description) do
+    Apipie::ResourceDescription.new(controller, name, dsl_data)
   end
 
-  describe "methods descriptions" do
+  let(:controller) { ApplicationController }
+  let(:name) { 'dummy' }
+  let(:dsl_data) { ActionController::Base.send(:_apipie_dsl_data_init) }
 
-    before(:each) do
-      @resource = Apipie::ResourceDescription.new(ApplicationController, "dummy")
-      a = Apipie::MethodDescription.new(:a, @resource, dsl_data)
-      b = Apipie::MethodDescription.new(:b, @resource, dsl_data)
-      c = Apipie::MethodDescription.new(:c, @resource, dsl_data)
-      @resource.add_method_description(a)
-      @resource.add_method_description(b)
-      @resource.add_method_description(c)
+  describe '#_methods' do
+    subject(:methods) { resource_description._methods }
+
+    context 'when has method descriptions' do
+      before do
+        resource_description.add_method_description(
+          Apipie::MethodDescription.new(:a, resource_description, dsl_data)
+        )
+        resource_description.add_method_description(
+          Apipie::MethodDescription.new(:b, resource_description, dsl_data)
+        )
+        resource_description.add_method_description(
+          Apipie::MethodDescription.new(:c, resource_description, dsl_data)
+        )
+      end
+
+      it 'should be ordered' do
+        expect(methods.keys).to eq([:a, :b, :c])
+      end
+    end
+  end
+
+  describe '#to_json' do
+    let(:json_data) { resource_description.to_json }
+
+    describe 'metadata' do
+      subject { json_data[:metadata] }
+
+      it { is_expected.to be_nil }
+
+      context 'when meta data are provided' do
+        let(:meta) { { length: 32, weight: '830g' } }
+        let(:dsl_data) { super().update({ meta: meta }) }
+
+        it { is_expected.to eq(meta) }
+      end
     end
 
-    it "should be ordered" do
-      expect(@resource._methods.keys).to eq([:a, :b, :c])
-      expect(@resource.to_json[:methods].map { |h| h[:name] }).to eq(['a', 'b', 'c'])
-    end
+    describe 'methods' do
+      subject(:methods_as_json) { json_data[:methods] }
 
-    it "should be still ordered" do
-      expect(@resource._methods.keys).to eq([:a, :b, :c])
-      expect(@resource.to_json[:methods].map { |h| h[:name] }).to eq(['a', 'b', 'c'])
-    end
+      context 'when has method descriptions' do
+        before do
+          resource_description.add_method_description(
+            Apipie::MethodDescription.new(:a, resource_description, dsl_data)
+          )
+          resource_description.add_method_description(
+            Apipie::MethodDescription.new(:b, resource_description, dsl_data)
+          )
+          resource_description.add_method_description(
+            Apipie::MethodDescription.new(:c, resource_description, dsl_data)
+          )
+        end
 
+        it 'should be ordered' do
+          expect(methods_as_json.map { |h| h[:name] }).to eq(['a', 'b', 'c'])
+        end
+      end
+    end
   end
 end

--- a/spec/lib/apipie/resource_description_spec.rb
+++ b/spec/lib/apipie/resource_description_spec.rb
@@ -2,11 +2,11 @@ require "spec_helper"
 
 describe Apipie::ResourceDescription do
   let(:resource_description) do
-    Apipie::ResourceDescription.new(controller, name, dsl_data)
+    Apipie::ResourceDescription.new(controller, id, dsl_data)
   end
 
   let(:controller) { ApplicationController }
-  let(:name) { 'dummy' }
+  let(:id) { 'dummy' }
   let(:dsl_data) { ActionController::Base.send(:_apipie_dsl_data_init) }
 
   describe '#_methods' do
@@ -67,6 +67,25 @@ describe Apipie::ResourceDescription do
           expect(methods_as_json.map { |h| h[:name] }).to eq(['a', 'b', 'c'])
         end
       end
+    end
+  end
+
+  describe 'name' do
+    subject { resource_description.name }
+
+    it { is_expected.to eq('Dummy') }
+
+    context 'when given id contains dashes' do
+      let(:id) { 'some-nested-resource' }
+
+      it { is_expected.to eq('Some::Nested::Resource') }
+    end
+
+    context 'when resource_name is given' do
+      let(:resource_name) { 'Some-Resource' }
+      let(:dsl_data) { super().merge!(resource_name: 'Some-Resource') }
+
+      it { is_expected.to eq(resource_name) }
     end
   end
 end


### PR DESCRIPTION
### Why
Closes https://github.com/Apipie/apipie-rails/issues/455

### How

- Updates `get_resource_name` to return a `-` seperated resource id. 
   The expected behavior when `Apipie.configuration.namespaced_resources?` is true is for a nested resource like `V1::Users::TweetsController` to return `v1-users-tweets` however it was returning `v1userstweets`

-  Uses the above dash separated format to return a readable nested resource name. Example if id is `some-nested-resource` `#name` will return `Some::Nested::Resource` that is later used in views.