### PR TITLE
Take into account validator options for  ParamDescription `required`

### DIFF
--- a/lib/apipie/param_description.rb
+++ b/lib/apipie/param_description.rb
@@ -57,6 +57,10 @@ module Apipie
         @from_concern = @options[:param_group][:from_concern]
       end
 
+      if validator.is_a?(Hash)
+        @options.merge!(validator.select{|k,v| k != :array_of })
+      end
+
       @method_description = method_description
       @name = concern_subst(name)
       @as = options[:as] || @name
@@ -85,9 +89,7 @@ module Apipie
       if validator
         if (validator != Hash) && (validator.is_a? Hash) && (validator[:array_of])
           @is_array = true
-          rest_of_options = validator
           validator = validator[:array_of]
-          options.merge!(rest_of_options.select{|k,v| k != :array_of })
           raise "an ':array_of =>' validator is allowed exclusively on response-only fields" unless @response_only
         end
         @validator = Validator::BaseValidator.find(self, validator, @options, block)

--- a/spec/lib/apipie/param_description_spec.rb
+++ b/spec/lib/apipie/param_description_spec.rb
@@ -239,7 +239,6 @@ describe Apipie::ParamDescription do
     end
   end
 
-
   describe "required_by_default config option" do
     context "parameters required by default" do
 
@@ -368,7 +367,6 @@ describe Apipie::ParamDescription do
       end
     end
   end
-
 
   describe 'sub params' do
 
@@ -508,4 +506,44 @@ describe Apipie::ParamDescription do
     end
   end
 
+  describe '#required' do
+    subject { param_description.required }
+
+    let(:param_description) do
+      Apipie::ParamDescription.new(method_desc, :param, validator, options)
+    end
+
+    context 'when is passed in options' do
+      let(:validator) { String }
+
+      context 'when is false' do
+        let(:options) { { required: false } }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context 'when is true' do
+        let(:options) { { required: true } }
+
+        it { is_expected.to eq(true) }
+      end
+    end
+
+    context 'when validator options are passed' do
+      let(:options) { { only_in: :response } }
+      let(:validator) { { array_of: String, required: required } }
+
+      context 'when required is false' do
+        let(:required) { false }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context 'when required is true' do
+        let(:required) { true }
+
+        it { is_expected.to eq(true) }
+      end
+    end
+  end
 end

--- a/spec/lib/apipie/param_group_spec.rb
+++ b/spec/lib/apipie/param_group_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
 describe "param groups" do
+  before { Apipie.reload_documentation }
 
   it "lets reuse the params description in more actions" do
     user_create_desc = Apipie["users#create"].params[:user]


### PR DESCRIPTION
### Why
When required was passed from validator options it was ignored 
Closes https://github.com/Apipie/apipie-rails/issues/709

### How
By using the validator options into ParamDescription options