### PR TITLE
Replace `get_resource_name` with `get_resource_id`

### DIFF
--- a/app/controllers/apipie/apipies_controller.rb
+++ b/app/controllers/apipie/apipies_controller.rb
@@ -119,7 +119,7 @@ module Apipie
           authorize_resource(resource)
         end
       else
-        @doc[:docs][:resources].select do |_resource_name, resource|
+        @doc[:docs][:resources].select do |_resource_id, resource|
           authorize_resource(resource)
         end
       end

--- a/lib/apipie/apipie_module.rb
+++ b/lib/apipie/apipie_module.rb
@@ -13,7 +13,7 @@ module Apipie
     app.to_json(version, resource_id, method_name, lang)
   end
 
-  def self.to_swagger_json(version = nil, resource_id = nil, method_name = nil, lang = nil, clear_warnings=true)
+  def self.to_swagger_json(version = nil, resource_id = nil, method_name = nil, lang = nil, clear_warnings = true)
     version ||= Apipie.configuration.default_version
     app.to_swagger_json(version, resource_id, method_name, lang, clear_warnings)
   end

--- a/lib/apipie/apipie_module.rb
+++ b/lib/apipie/apipie_module.rb
@@ -8,14 +8,14 @@ module Apipie
     @application ||= Apipie::Application.new
   end
 
-  def self.to_json(version = nil, resource_name = nil, method_name = nil, lang = nil)
+  def self.to_json(version = nil, resource_id = nil, method_name = nil, lang = nil)
     version ||= Apipie.configuration.default_version
-    app.to_json(version, resource_name, method_name, lang)
+    app.to_json(version, resource_id, method_name, lang)
   end
 
-  def self.to_swagger_json(version = nil, resource_name = nil, method_name = nil, lang = nil, clear_warnings = true)
+  def self.to_swagger_json(version = nil, resource_id = nil, method_name = nil, lang = nil, clear_warnings=true)
     version ||= Apipie.configuration.default_version
-    app.to_swagger_json(version, resource_name, method_name, lang, clear_warnings)
+    app.to_swagger_json(version, resource_id, method_name, lang, clear_warnings)
   end
 
   def self.json_schema_for_method_response(controller_name, method_name, return_code, allow_nulls)

--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -268,13 +268,13 @@ module Apipie
     end
 
     def to_swagger_json(version, resource_id, method_name, language, clear_warnings = false)
-      return unless valid_search_args?(version, resource_name, method_name)
+      return unless valid_search_args?(version, resource_id, method_name)
 
       resources =
         Apipie::Generator::Swagger::ResourceDescriptionsCollection
         .new(resource_descriptions)
         .filter(
-          resource_name: resource_id,
+          resource_id: resource_id,
           method_name: method_name,
           version: version
         )

--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -110,8 +110,7 @@ module Apipie
         # some method. Updating just meta data from dsl
         resource_description.update_from_dsl_data(dsl_data) if dsl_data
       else
-        resource_description = Apipie::ResourceDescription.
-          new(controller, resource_id, dsl_data, version)
+        resource_description = Apipie::ResourceDescription.new(controller, resource_id, dsl_data, version)
 
         Apipie.debug("@resource_descriptions[#{version}][#{resource_id}] = #{resource_description}")
         @resource_descriptions[version][resource_id] ||= resource_description

--- a/lib/apipie/dsl_definition.rb
+++ b/lib/apipie/dsl_definition.rb
@@ -51,9 +51,6 @@ module Apipie
     end
 
     module Resource
-      # by default, the resource id is derived from controller_name
-      # it can be overwritten with.
-      #
       #    resource_id "my_own_resource_id"
       def resource_id(resource_id)
         Apipie.set_resource_id(@controller, resource_id)
@@ -529,8 +526,10 @@ module Apipie
       alias apipie_update_params apipie_update_methods
 
       def _apipie_concern_subst
-        @_apipie_concern_subst ||= {:controller_path => self.controller_path,
-                                    :resource_id => Apipie.get_resource_name(self)}
+        @_apipie_concern_subst ||= {
+          controller_path: self.controller_path,
+          resource_id: Apipie.get_resource_id(self)
+        }
       end
 
       def _apipie_perform_concern_subst(string)

--- a/lib/apipie/extractor.rb
+++ b/lib/apipie/extractor.rb
@@ -154,7 +154,7 @@ module Apipie
       def update_api_descriptions
         apis_from_docs = all_apis_from_docs
         @apis_from_routes.each do |(controller, action), new_apis|
-          method_key = "#{Apipie.get_resource_name(controller.safe_constantize || next)}##{action}"
+          method_key = "#{Apipie.get_resource_id(controller.safe_constantize || next)}##{action}"
           old_apis = apis_from_docs[method_key] || []
           new_apis.each do |new_api|
             new_api[:path]&.sub!(/\(\.:format\)$/,"")

--- a/lib/apipie/extractor/collector.rb
+++ b/lib/apipie/extractor/collector.rb
@@ -19,7 +19,7 @@ module Apipie
       def ignore_call?(record)
         return true unless record[:controller]
         return true if @ignored.include?(record[:controller].name)
-        return true if @ignored.include?("#{Apipie.get_resource_name(record[:controller].name)}##{record[:action]}")
+        return true if @ignored.include?("#{Apipie.resource_id(record[:controller].name)}##{record[:action]}")
         return true unless @api_controllers_paths.include?(controller_full_path(record[:controller]))
       end
 
@@ -33,7 +33,7 @@ module Apipie
       end
 
       def add_to_records(record)
-        key = "#{Apipie.get_resource_name(record[:controller])}##{record[:action]}"
+        key = "#{Apipie.get_resource_id(record[:controller])}##{record[:action]}"
         @records[key] << record
       end
 

--- a/lib/apipie/generator/swagger/resource_description_collection.rb
+++ b/lib/apipie/generator/swagger/resource_description_collection.rb
@@ -5,14 +5,14 @@ class Apipie::Generator::Swagger::ResourceDescriptionsCollection
   end
 
   # @return [Array<Apipie::ResourceDescription>]
-  def filter(version:, resource_name:, method_name: nil)
+  def filter(version:, resource_id:, method_name: nil)
     resources = []
 
-    # If resource_name is blank, take just resources which have some methods because
+    # If resource_id is blank, take just resources which have some methods because
     # we dont want to show eg ApplicationController as resource
     # otherwise, take only the specified resource
-    @resource_descriptions[version].each do |resource_description_name, resource_description|
-      if (resource_name.blank? && resource_description._methods.present?) || resource_description_name == resource_name
+    @resource_descriptions[version].each do |resource_description_id, resource_description|
+      if (resource_id.blank? && resource_description._methods.present?) || resource_description_id == resource_id
         resources << resource_description
       end
     end

--- a/lib/apipie/resource_description.rb
+++ b/lib/apipie/resource_description.rb
@@ -65,7 +65,7 @@ module Apipie
     alias _name name
 
     def add_method_description(method_description)
-      Apipie.debug "@resource_descriptions[#{self._version}][#{self._name}]._methods[#{method_description.method}] = #{method_description}"
+      Apipie.debug "@resource_descriptions[#{self._version}][#{self._id}]._methods[#{method_description.method}] = #{method_description}"
       @_methods[method_description.method.to_sym] = method_description
     end
 

--- a/lib/tasks/apipie.rake
+++ b/lib/tasks/apipie.rake
@@ -254,11 +254,11 @@ namespace :apipie do
   end
 
   def generate_resource_pages(version, file_base, doc, include_json = false, lang = nil)
-    doc[:docs][:resources].each do |resource_name, _|
-      resource_file_base = File.join(file_base, resource_name.to_s)
+    doc[:docs][:resources].each do |resource_id, _|
+      resource_file_base = File.join(file_base, resource_id.to_s)
       FileUtils.mkdir_p(File.dirname(resource_file_base)) unless File.exist?(File.dirname(resource_file_base))
 
-      doc = Apipie.to_json(version, resource_name, nil, lang)
+      doc = Apipie.to_json(version, resource_id, nil, lang)
       doc[:docs][:link_extension] = (lang ? ".#{lang}.html" : ".html")
       render_page("#{resource_file_base}#{lang_ext(lang)}.html", "resource", {:doc => doc[:docs],
         :resource => doc[:docs][:resources].first, :language => lang, :languages => Apipie.configuration.languages})
@@ -267,12 +267,12 @@ namespace :apipie do
   end
 
   def generate_method_pages(version, file_base, doc, include_json = false, lang = nil)
-    doc[:docs][:resources].each do |resource_name, resource_params|
+    doc[:docs][:resources].each do |resource_id, resource_params|
       resource_params[:methods].each do |method|
-        method_file_base = File.join(file_base, resource_name.to_s, method[:name].to_s)
+        method_file_base = File.join(file_base, resource_id.to_s, method[:name].to_s)
         FileUtils.mkdir_p(File.dirname(method_file_base)) unless File.exist?(File.dirname(method_file_base))
 
-        doc = Apipie.to_json(version, resource_name, method[:name], lang)
+        doc = Apipie.to_json(version, resource_id, method[:name], lang)
         doc[:docs][:link_extension] = (lang ? ".#{lang}.html" : ".html")
         render_page("#{method_file_base}#{lang_ext(lang)}.html", "method", {:doc => doc[:docs],
                                                            :resource => doc[:docs][:resources].first,

--- a/spec/controllers/api/v2/nested/resources_controller_spec.rb
+++ b/spec/controllers/api/v2/nested/resources_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe Api::V2::Nested::ResourcesController do
-  describe "resource id" do
-    subject { Apipie.get_resource_name(Api::V2::Nested::ResourcesController) }
+  describe '.get_resource_id' do
+    subject { Apipie.get_resource_id(Api::V2::Nested::ResourcesController) }
 
     it "should have resource_id set" do
       expect(subject).to eq("resource")

--- a/spec/lib/apipie/application_spec.rb
+++ b/spec/lib/apipie/application_spec.rb
@@ -16,14 +16,11 @@ describe Apipie::Application do
 
   end
 
-  describe '.get_resource_name' do
-    subject(:get_resource_name) do
-      Apipie.get_resource_name(Api::V2::Nested::ArchitecturesController)
-    end
-
+  shared_examples 'resource id' do
+    let(:resource_class) { Api::V2::Nested::ArchitecturesController }
     let(:base_url) { '/some-api' }
 
-    before { allow(Apipie.app).to receive(:get_base_url).and_return(base_url) }
+    before { allow(described_class).to receive(:get_base_url).and_return(base_url) }
 
     context "with namespaced_resources enabled" do
       before { Apipie.configuration.namespaced_resources = true }
@@ -37,7 +34,7 @@ describe Apipie::Application do
         let(:base_url) { nil }
 
         it "should not raise an error" do
-          expect { get_resource_name }.not_to raise_error
+          expect { method_call }.not_to raise_error
         end
       end
     end
@@ -49,5 +46,17 @@ describe Apipie::Application do
         is_expected.to eq('architectures')
       end
     end
+  end
+
+  describe '.get_resource_id' do
+    subject(:method_call) { Apipie.get_resource_id(resource_class) }
+
+    it_behaves_like 'resource id'
+  end
+
+  describe '.get_resource_name' do
+    subject(:method_call) { Apipie.get_resource_name(resource_class) }
+
+    it_behaves_like 'resource id'
   end
 end

--- a/spec/lib/apipie/generator/swagger/method_description/api_schema_service_spec.rb
+++ b/spec/lib/apipie/generator/swagger/method_description/api_schema_service_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Apipie::Generator::Swagger::MethodDescription::ApiSchemaService do
   let(:path) { '/api' }
   let(:http_method) { 'get' }
-  let(:resource_name) { 'users' }
+  let(:resource_id) { 'users' }
   let(:method_description_description) { nil }
   let(:tags) { [] }
 
@@ -20,7 +20,7 @@ describe Apipie::Generator::Swagger::MethodDescription::ApiSchemaService do
   end
 
   let(:resource_desc) do
-    Apipie::ResourceDescription.new(UsersController, resource_name)
+    Apipie::ResourceDescription.new(UsersController, resource_id)
   end
 
   let(:method_description) do
@@ -56,7 +56,7 @@ describe Apipie::Generator::Swagger::MethodDescription::ApiSchemaService do
   describe 'tags' do
     subject { service.call[path][http_method][:tags] }
 
-    it { is_expected.to eq([resource_name]) }
+    it { is_expected.to eq([resource_id]) }
 
     context 'when tags are available' do
       let(:tags) { ['Tag 1', 'Tag 2'] }

--- a/spec/lib/apipie/generator/swagger/resource_description_composite_spec.rb
+++ b/spec/lib/apipie/generator/swagger/resource_description_composite_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe Apipie::Generator::Swagger::ResourceDescriptionComposite do
   let(:dsl_data) { {} }
-  let(:resource_name) { 'pets' }
+  let(:resource_id) { 'pets' }
   let(:resource_description) do
-    Apipie::ResourceDescription.new(PetsController, resource_name, dsl_data)
+    Apipie::ResourceDescription.new(PetsController, resource_id, dsl_data)
   end
 
   let(:resource_descriptions) { [resource_description] }
@@ -26,7 +26,7 @@ describe Apipie::Generator::Swagger::ResourceDescriptionComposite do
         it 'returns the name and description' do
           expect(tag).to eq(
             {
-              name: resource_name,
+              name: resource_id,
               description: resource_description._full_description
             }
           )

--- a/spec/lib/apipie/generator/swagger/resource_descriptions_collection_spec.rb
+++ b/spec/lib/apipie/generator/swagger/resource_descriptions_collection_spec.rb
@@ -27,13 +27,13 @@ describe Apipie::Generator::Swagger::ResourceDescriptionsCollection do
     subject(:filtered_resource_descriptions) do
       collection.filter(
         version: version,
-        resource_name: resource_name,
+        resource_id: resource_id,
         method_name: method_name
       )
     end
 
     let(:version) { 'development' }
-    let(:resource_name) { users_resource_description._id }
+    let(:resource_id) { users_resource_description._id }
     let(:method_name) { nil }
 
     it 'filters resources for the given version and resource name' do

--- a/spec/lib/apipie/generator/swagger/schema_spec.rb
+++ b/spec/lib/apipie/generator/swagger/schema_spec.rb
@@ -5,11 +5,11 @@ describe Apipie::Generator::Swagger::Schema do
   let(:language) { :ok }
   let(:clear_warnings) { :ok }
   let(:dsl_data) { {} }
-  let(:resource_name) { 'pets' }
+  let(:resource_id) { 'pets' }
   let(:resource_descriptions) { [resource_description] }
 
   let(:resource_description) do
-    Apipie::ResourceDescription.new(PetsController, resource_name, dsl_data)
+    Apipie::ResourceDescription.new(PetsController, resource_id, dsl_data)
   end
 
   let(:schema_generator) do


### PR DESCRIPTION
### Why 

Although the function is named `get_resource_name` in reality it's generating the ID that is used as an id of the resource description as well as in the URLs of apipie.

Ideally what name is displayed in docs should have nothing to do with the internals of Apipie.

### How
It deprecates `.get_resource_name` in favor of `.get_resource_id` to avoid confusion with `ResourceDescription#name`

