### PR TITLE
Add missing 'returns' translation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,7 @@ en:
     headers: Headers
     header_name: Header name
     code: Code
+    returns: Returns
     deprecated: Deprecated
     deprecation_details: Deprecation details
     deprecation:


### PR DESCRIPTION
Closes #867

It's currently being used in the [`_method_detail.erb`](https://github.com/Apipie/apipie-rails/blob/master/app/views/apipie/apipies/_method_detail.erb#L40) partial.