### PR TITLE
Fix startup crash due to typo

### DIFF
--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -227,7 +227,7 @@ module Apipie
 
     def remove_method_description(resource, versions, method_name)
       versions.each do |version|
-        resource = resource_id(resource)
+        resource = get_resource_id(resource)
         if resource_description = get_resource_description("#{version}##{resource}")
           resource_description.remove_method_description(method_name)
         end

--- a/spec/dummy/app/controllers/api/v2/architectures_controller.rb
+++ b/spec/dummy/app/controllers/api/v2/architectures_controller.rb
@@ -22,7 +22,8 @@ module Api
       def update
       end
 
-      api :DELETE, "/architecturess/:id/", "Delete an architecture."
+      api! "Delete an architecture."
+      api_version "2.0" # forces removal of the method description
       def destroy
       end
     end


### PR DESCRIPTION
This should be `get_resource_id`. The method `remove_method_description` was not exercised by the specs so it wasn't caught. (see #864)

This was causing apipie to crash during application boot.