### PR TITLE
Improve performance of route detection

### DIFF
--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -45,6 +45,12 @@ Dummy::Application.routes.draw do
       get "/pets/returns_response_with_valid_array" => "pets#returns_response_with_valid_array"
       get "/pets/returns_response_with_invalid_array" => "pets#returns_response_with_invalid_array"
       get "/pets/undocumented_method" => "pets#undocumented_method"
+
+      # generate 1000 routes for testing performance of route matching used by api! method
+      # it's okay that these don't go anywhere real
+      1000.times do |i|
+        get "/api/v1/pets/#{i}" => "pets#{i}#show"
+      end
     end
 
     apipie


### PR DESCRIPTION
In large apps with many routes (1500+), using the `api!` method would be quite slow because `routes_for_action` looped over every route trying to constantize the controller name. Compound this by the number of times `api!` is used in the app.

Furthermore, each controller utilizing `api!` would constantize the next controller using `api!`, which would constantize the next controller and so on, recursively and potentially very deeply.

This change caches a hash of controller+action => routes using only the controller name, avoiding the time-consuming loops, constantization, and recursion.

As a bonus, the cache is cleared when documentation is reloaded, fixing a bug where new routes added while the app is running wouldn't get picked up.

On small apps with not too many routes, there isn't much of a performance gain.

To test this, I added 1000 routes to the dummy app's routes file.

## Before
<img width="376" alt="image" src="https://github.com/Apipie/apipie-rails/assets/135457/e6c30064-13bd-4538-bce8-454981c5160d">

## After
<img width="379" alt="image" src="https://github.com/Apipie/apipie-rails/assets/135457/d31ad6ea-7542-4796-a817-386eac9343ae">

## Master
(for comparison - without 1000 routes)
<img width="387" alt="image" src="https://github.com/Apipie/apipie-rails/assets/135457/72337ede-a837-48b4-ab52-ee520c78cb03">