### PR TITLE
Allow resource_name to be inherited

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ Rails:
 
 AllCops:
   NewCops: enable
+  TargetRubyVersion: 2.6
 
 Layout/LineLength:
   Max: 140
@@ -69,43 +70,43 @@ Style/HashSyntax:
 
 Metrics/ParameterLists:
   Exclude:
-    - 'lib/apipie/generator/swagger/context.rb'
+    - "lib/apipie/generator/swagger/context.rb"
 
 Style/Documentation:
   Exclude:
-    - 'app/controllers/apipie/apipies_controller.rb'
-    - 'app/helpers/apipie_helper.rb'
-    - 'lib/apipie/apipie_module.rb'
-    - 'lib/apipie/application.rb'
-    - 'lib/apipie/configuration.rb'
-    - 'lib/apipie/core_ext/route.rb'
-    - 'lib/apipie/dsl_definition.rb'
-    - 'lib/apipie/error_description.rb'
-    - 'lib/apipie/errors.rb'
-    - 'lib/apipie/extractor.rb'
-    - 'lib/apipie/extractor/collector.rb'
-    - 'lib/apipie/extractor/recorder.rb'
-    - 'lib/apipie/extractor/writer.rb'
-    - 'lib/apipie/generator/generator.rb'
-    - 'lib/apipie/generator/swagger/**/*'
-    - 'lib/apipie/helpers.rb'
-    - 'lib/apipie/markup.rb'
-    - 'lib/apipie/method_description.rb'
-    - 'lib/apipie/method_description/api.rb'
-    - 'lib/apipie/middleware/checksum_in_headers.rb'
-    - 'lib/apipie/railtie.rb'
-    - 'lib/apipie/response_description.rb'
-    - 'lib/apipie/response_description_adapter.rb'
-    - 'lib/apipie/routes_formatter.rb'
-    - 'lib/apipie/routing.rb'
-    - 'lib/apipie/rspec/response_validation_helper.rb'
-    - 'lib/apipie/swagger_generator.rb'
-    - 'lib/apipie/see_description.rb'
-    - 'lib/apipie/static_dispatcher.rb'
-    - 'lib/apipie/tag_list_description.rb'
-    - 'lib/apipie/validator.rb'
-    - 'lib/generators/apipie/install/install_generator.rb'
-    - 'lib/generators/apipie/views_generator.rb'
+    - "app/controllers/apipie/apipies_controller.rb"
+    - "app/helpers/apipie_helper.rb"
+    - "lib/apipie/apipie_module.rb"
+    - "lib/apipie/application.rb"
+    - "lib/apipie/configuration.rb"
+    - "lib/apipie/core_ext/route.rb"
+    - "lib/apipie/dsl_definition.rb"
+    - "lib/apipie/error_description.rb"
+    - "lib/apipie/errors.rb"
+    - "lib/apipie/extractor.rb"
+    - "lib/apipie/extractor/collector.rb"
+    - "lib/apipie/extractor/recorder.rb"
+    - "lib/apipie/extractor/writer.rb"
+    - "lib/apipie/generator/generator.rb"
+    - "lib/apipie/generator/swagger/**/*"
+    - "lib/apipie/helpers.rb"
+    - "lib/apipie/markup.rb"
+    - "lib/apipie/method_description.rb"
+    - "lib/apipie/method_description/api.rb"
+    - "lib/apipie/middleware/checksum_in_headers.rb"
+    - "lib/apipie/railtie.rb"
+    - "lib/apipie/response_description.rb"
+    - "lib/apipie/response_description_adapter.rb"
+    - "lib/apipie/routes_formatter.rb"
+    - "lib/apipie/routing.rb"
+    - "lib/apipie/rspec/response_validation_helper.rb"
+    - "lib/apipie/swagger_generator.rb"
+    - "lib/apipie/see_description.rb"
+    - "lib/apipie/static_dispatcher.rb"
+    - "lib/apipie/tag_list_description.rb"
+    - "lib/apipie/validator.rb"
+    - "lib/generators/apipie/install/install_generator.rb"
+    - "lib/generators/apipie/views_generator.rb"
     - spec/support/custom_bool_validator.rb
     - spec/lib/validators/array_validator_spec.rb
     - spec/dummy/**/*.rb
@@ -122,6 +123,6 @@ Naming/BlockForwarding:
 
 Lint/MissingSuper:
   Exclude:
-    - 'lib/apipie/errors.rb'
-    - 'lib/apipie/response_description_adapter.rb'
-    - 'lib/apipie/validator.rb'
+    - "lib/apipie/errors.rb"
+    - "lib/apipie/response_description_adapter.rb"
+    - "lib/apipie/validator.rb"

--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,10 @@ resource_id
 name
   Human readable name of resource. By default ``class.name.humanize`` is used.
 
+  - Can be specified as a proc, which will receive the controller class as an argument.
+  - Can be a symbol, which will be sent to the controller class to get the name.
+  - Can be a string, which will be used as is.
+
 short (also short_description)
   Short description of the resource (it's shown on both the list of resources, and resource details)
 

--- a/README.rst
+++ b/README.rst
@@ -1180,7 +1180,7 @@ Here is an example of how to rescue and process a +ParamMissing+ or
 +ParamInvalid+ error from within the ApplicationController.
 
 .. code:: ruby
-  
+
   class ApplicationController < ActionController::Base
 
     # ParamError is superclass of ParamMissing, ParamInvalid
@@ -1928,11 +1928,13 @@ And if you write one on your own, don't hesitate to share it with us!
 Since this gem does not have a Gemfile, you need to specify it in your shell with:
 
 .. code:: shell
+
    BUNDLE_GEMFILE='gemfiles/Gemfile.rails61'
 
 Then, you can install dependencies and run the test suite:
 
 .. code:: shell
+
    > bundle install
    > bundle exec rspec
 

--- a/spec/controllers/api/v2/nested/resources_controller_spec.rb
+++ b/spec/controllers/api/v2/nested/resources_controller_spec.rb
@@ -1,6 +1,22 @@
 require 'spec_helper'
 
 describe Api::V2::Nested::ResourcesController do
+  let(:resource_description) { Apipie.get_resource_description(described_class, "2.0") }
+
+  describe "resource description" do
+    describe 'version' do
+      subject { resource_description._version }
+
+      it { is_expected.to eq('2.0') }
+    end
+
+    describe 'name' do
+      subject { resource_description.name }
+
+      it { is_expected.to eq('Rsrcs') }
+    end
+  end
+
   describe '.get_resource_id' do
     subject { Apipie.get_resource_id(Api::V2::Nested::ResourcesController) }
 

--- a/spec/controllers/api/v2/sub/footguns_controller_spec.rb
+++ b/spec/controllers/api/v2/sub/footguns_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-describe Api::V2::ArchitecturesController do
-  let(:resource_description) { Apipie.get_resource_description(described_class, "2.0") }
+describe Api::V2::Sub::FootgunsController do
+  let(:resource_description) { Apipie.get_resource_description(described_class, '2.0') }
 
-  describe "resource description" do
+  describe 'resource description' do
     describe 'version' do
       subject { resource_description._version }
 
@@ -13,7 +13,7 @@ describe Api::V2::ArchitecturesController do
     describe 'name' do
       subject { resource_description.name }
 
-      it { is_expected.to eq('Architectures') }
+      it { is_expected.to eq('snugtooF') }
     end
   end
 end

--- a/spec/dummy/app/controllers/api/v2/base_controller.rb
+++ b/spec/dummy/app/controllers/api/v2/base_controller.rb
@@ -5,6 +5,12 @@ module Api
         api_version '2.0'
         app_info 'Version 2.0 description'
         api_base_url '/api/v2'
+
+        name :reversed_name
+      end
+
+      def self.reversed_name
+        controller_name.capitalize.reverse
       end
     end
   end

--- a/spec/dummy/app/controllers/api/v2/empty_middle_controller.rb
+++ b/spec/dummy/app/controllers/api/v2/empty_middle_controller.rb
@@ -1,0 +1,9 @@
+module Api
+  module V2
+    class EmptyMiddleController < V2::BaseController
+      # This is an empty controller, used to test cases where controllers
+      # may inherit from a middle controler that does not define a resource_description,
+      # but the middle controller's parent does.
+    end
+  end
+end

--- a/spec/dummy/app/controllers/api/v2/nested/resources_controller.rb
+++ b/spec/dummy/app/controllers/api/v2/nested/resources_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V2
     class Nested::ResourcesController < V2::BaseController
-      resource_description do 
-        name 'Resources'
+      resource_description do
+        name ->(controller) { controller.controller_name.delete('aeiou').capitalize }
         resource_id "resource"
       end
       api :GET, "/nested/resources/", "List all nested resources."

--- a/spec/dummy/app/controllers/api/v2/sub/footguns_controller.rb
+++ b/spec/dummy/app/controllers/api/v2/sub/footguns_controller.rb
@@ -1,0 +1,30 @@
+module Api
+  module V2
+    module Sub
+      class FootgunsController < V2::EmptyMiddleController
+        resource_description do
+          short 'Footguns are bad'
+        end
+
+        api :GET, '/footguns/', 'List all footguns.'
+        def index; end
+
+        api :GET, '/footguns/:id/', 'Show a footgun.'
+        def show; end
+
+        api :POST, '/footguns/', 'Create a footgun.'
+        def create; end
+
+        api :PUT, '/footguns/:id/', 'Update a footgun.'
+        param :footgun, Hash, :required => true do
+          param :name, String
+        end
+        def update; end
+
+        api! 'Delete a footgun.'
+        api_version '2.0' # forces removal of the method description
+        def destroy; end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is helpful if you have a very structured hierarchy of API controllers and would like to define the naming logic once in a base controller.

* Allow resource_name to be a string, symbol, or proc
* Search all the way up the controller hierarchy for a value
* Continue searching even if a particular controller doesn't have a `resource_description` block

Edit: I had to set Rubocop's target Ruby version to 2.6 in order to get a bunch of offenses to go away. I'm not sure why that suddenly started happening (my PR from last week didn't have any issues).