### PR TITLE
Fix error climbing controller hierarchy

### DIFF
--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -454,7 +454,7 @@ module Apipie
     end
 
     def version_prefix(klass)
-      version = controller_versions(klass.to_s).first
+      version = controller_versions(klass).first
       base_url = get_base_url(version)
       return "/" if base_url.blank?
       base_url[1..-1] + "/"

--- a/lib/apipie/resource_description.rb
+++ b/lib/apipie/resource_description.rb
@@ -101,7 +101,9 @@ module Apipie
       Apipie.full_url crumbs.join('/')
     end
 
-    def api_url; "#{Apipie.api_base_url(_version)}#{@_path}"; end
+    def api_url
+      "#{Apipie.api_base_url(_version)}#{@_path}"
+    end
 
     def valid_method_name?(method_name)
       @_methods.keys.map(&:to_s).include?(method_name.to_s)

--- a/spec/controllers/api/v2/empty_middle_controller_spec.rb
+++ b/spec/controllers/api/v2/empty_middle_controller_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Api::V2::EmptyMiddleController do
+  let(:resource_description) { Apipie.get_resource_description(described_class, '2.0') }
+
+  describe 'resource description' do
+    subject { resource_description }
+
+    context 'when namespaced resources are enabled' do
+      before { Apipie.configuration.namespaced_resources = true }
+      after { Apipie.configuration.namespaced_resources = false }
+
+      # we don't actually expect the resource description to be nil, but resource IDs
+      # are computed at file load time, and altering the value of namespaced_resources
+      # after the fact doesn't change the resource ID, so it can't be found
+      it { is_expected.to be_nil }
+    end
+
+    context 'when namespaced resources are disabled' do
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/dummy/app/controllers/api/v2/empty_middle_controller.rb
+++ b/spec/dummy/app/controllers/api/v2/empty_middle_controller.rb
@@ -4,6 +4,11 @@ module Api
       # This is an empty controller, used to test cases where controllers
       # may inherit from a middle controler that does not define a resource_description,
       # but the middle controller's parent does.
+
+      def inconsequential_method
+        # This method is here to ensure that the controller is not empty.
+        # It triggers method_added, which is used to add the resource description.
+      end
     end
   end
 end


### PR DESCRIPTION
When using namespaced resources, climbing the controller hierarchy was broken in really specific circumstances.

Bug introduced in https://github.com/Apipie/apipie-rails/pull/872
