### PR TITLE
Fix typo in Collector

### DIFF
--- a/lib/apipie/extractor/collector.rb
+++ b/lib/apipie/extractor/collector.rb
@@ -19,7 +19,7 @@ module Apipie
       def ignore_call?(record)
         return true unless record[:controller]
         return true if @ignored.include?(record[:controller].name)
-        return true if @ignored.include?("#{Apipie.resource_id(record[:controller].name)}##{record[:action]}")
+        return true if @ignored.include?("#{Apipie.get_resource_id(record[:controller].name)}##{record[:action]}")
         return true unless @api_controllers_paths.include?(controller_full_path(record[:controller]))
       end
 

--- a/spec/lib/apipie/extractor/collector_spec.rb
+++ b/spec/lib/apipie/extractor/collector_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Apipie::Extractor::Collector do
+  let(:recorder) { described_class.new }
+
+  describe '#ignore_call?' do
+    subject { recorder.ignore_call?(record) }
+
+    let(:record) { { controller: controller, action: action } }
+    let(:controller) { ActionController::Base }
+    let(:action) { nil }
+
+    context 'when controller is nil' do
+      let(:controller) { nil }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when controller is ignored' do
+      before do
+        allow(Apipie.configuration).to receive(:ignored_by_recorder).and_return(['ActionController::Bas'])
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when resource#method is ignored' do
+      let(:action) { 'ignored_action' }
+
+      before do
+        allow(Apipie.configuration).to receive(:ignored_by_recorder).and_return(['ActionController::Bas#ignored_action'])
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when controller is not an API controller' do
+      before do
+        allow(Apipie::Extractor).to receive(:controller_path).with('action_controller/base').and_return('foo')
+        allow(Apipie).to receive(:api_controllers_paths).and_return([])
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when controller is an API controller' do
+      before do
+        allow(Apipie::Extractor).to receive(:controller_path).with('action_controller/base').and_return('foo')
+        allow(Apipie).to receive(:api_controllers_paths).and_return(['foo'])
+      end
+
+      it { is_expected.to be_falsey }
+    end
+  end
+end


### PR DESCRIPTION
This should be `get_resource_id`. The method `ignore_call?` wasn't exercised by the specs so it wasn't caught. (see #864)

This was causing an exception when recording examples.
