### PR TITLE
Fix deprecated `content_type` on Rails >= 6

### DIFF
--- a/lib/apipie/extractor/recorder.rb
+++ b/lib/apipie/extractor/recorder.rb
@@ -48,7 +48,7 @@ module Apipie
         else
           @query = request.query_string
         end
-        if response.content_type != 'application/pdf'
+        if response.media_type != 'application/pdf'
           @response_data = parse_data(response.body)
         end
         @code = response.code


### PR DESCRIPTION
DEPRECATION WARNING: Rails 6.1 will return Content-Type header without modification. If you want just the MIME type, please use `#media_type` instead. (called from analyze_functional_test at ~/apipie-rails/lib/apipie/extractor/recorder.rb:51)
