### PR TITLE
Swagger: Adds option to skip default tags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1730,6 +1730,9 @@ There are several configuration parameters that determine the structure of the g
     See [https://swagger.io/docs/specification/2-0/authentication/] for details of what values can be specified
     By default, no security is defined.
 
+``config.generator.swagger.skip_default_tags``
+    By setting ``false`` (default): The resource name for e.g. ``/pets/{petId}`` will automatically be added as a tag ``pets``.
+    By setting ``true``: The tags needs to be explicitly added to the resource using the DSL.
 
 Known limitations of the current implementation
 -------------------------------------------------

--- a/lib/apipie/generator/swagger/config.rb
+++ b/lib/apipie/generator/swagger/config.rb
@@ -10,7 +10,7 @@ module Apipie
                              :json_input_uses_refs, :suppress_warnings, :api_host,
                              :generate_x_computed_id_field, :allow_additional_properties_in_response,
                              :responses_use_refs, :schemes, :security_definitions,
-                             :global_security].freeze
+                             :global_security, :skip_default_tags].freeze
 
         attr_accessor(*CONFIG_ATTRIBUTES)
 
@@ -43,6 +43,7 @@ module Apipie
         alias include_warning_tags? include_warning_tags
         alias json_input_uses_refs? json_input_uses_refs
         alias responses_use_refs? responses_use_refs
+        alias skip_default_tags? skip_default_tags
         alias generate_x_computed_id_field? generate_x_computed_id_field
         alias swagger_include_warning_tags? swagger_include_warning_tags
         alias swagger_json_input_uses_refs? swagger_json_input_uses_refs
@@ -61,6 +62,7 @@ module Apipie
           @schemes = [:https]
           @security_definitions = {}
           @global_security = []
+          @skip_default_tags = false
         end
 
         def self.deprecated_methods

--- a/lib/apipie/generator/swagger/method_description/api_schema_service.rb
+++ b/lib/apipie/generator/swagger/method_description/api_schema_service.rb
@@ -47,9 +47,12 @@ class Apipie::Generator::Swagger::MethodDescription::ApiSchemaService
   end
 
   def tags
-    [@method_description.resource._id] +
-      warning_tags +
-      @method_description.tag_list.tags
+    tags = if Apipie.configuration.generator.swagger.skip_default_tags?
+      []
+    else
+      [@method_description.resource._id]
+    end
+    tags + warning_tags + @method_description.tag_list.tags
   end
 
   def warning_tags

--- a/lib/apipie/generator/swagger/method_description/api_schema_service.rb
+++ b/lib/apipie/generator/swagger/method_description/api_schema_service.rb
@@ -48,10 +48,10 @@ class Apipie::Generator::Swagger::MethodDescription::ApiSchemaService
 
   def tags
     tags = if Apipie.configuration.generator.swagger.skip_default_tags?
-      []
-    else
-      [@method_description.resource._id]
-    end
+             []
+           else
+             [@method_description.resource._id]
+           end
     tags + warning_tags + @method_description.tag_list.tags
   end
 

--- a/spec/lib/apipie/generator/swagger/method_description/api_schema_service_spec.rb
+++ b/spec/lib/apipie/generator/swagger/method_description/api_schema_service_spec.rb
@@ -64,14 +64,14 @@ describe Apipie::Generator::Swagger::MethodDescription::ApiSchemaService do
       it { is_expected.to include(*tags) }
     end
 
-    context "when Apipie.configuration.generator.swagger.skip_default_tags is enabled" do
+    context 'when Apipie.configuration.generator.swagger.skip_default_tags is enabled' do
       before { Apipie.configuration.generator.swagger.skip_default_tags = true }
       after { Apipie.configuration.generator.swagger.skip_default_tags = false }
 
       it { is_expected.to be_empty }
 
-      context "when tags are available" do
-        let(:tags) { ["Tag 1", "Tag 2"] }
+      context 'when tags are available' do
+        let(:tags) { ['Tag 1', 'Tag 2'] }
 
         it { is_expected.to eq(tags) }
       end

--- a/spec/lib/apipie/generator/swagger/method_description/api_schema_service_spec.rb
+++ b/spec/lib/apipie/generator/swagger/method_description/api_schema_service_spec.rb
@@ -64,6 +64,19 @@ describe Apipie::Generator::Swagger::MethodDescription::ApiSchemaService do
       it { is_expected.to include(*tags) }
     end
 
+    context "when Apipie.configuration.generator.swagger.skip_default_tags is enabled" do
+      before { Apipie.configuration.generator.swagger.skip_default_tags = true }
+      after { Apipie.configuration.generator.swagger.skip_default_tags = false }
+
+      it { is_expected.to be_empty }
+
+      context "when tags are available" do
+        let(:tags) { ["Tag 1", "Tag 2"] }
+
+        it { is_expected.to eq(tags) }
+      end
+    end
+
     context 'when Apipie.configuration.generator.swagger.include_warning_tags is enabled' do
       before { Apipie.configuration.generator.swagger.include_warning_tags = true }
 


### PR DESCRIPTION
- This option allows the resource tags to be manually specified
- Fixes #759
