### PR TITLE
Fix Swagger warnings for properties

### DIFF
--- a/lib/apipie/generator/swagger/param_description/builder.rb
+++ b/lib/apipie/generator/swagger/param_description/builder.rb
@@ -79,7 +79,7 @@ class Apipie::Generator::Swagger::ParamDescription::Builder
   end
 
   def required?
-    required_from_path? || (!@in_schema && @param_description.required)
+    required_from_path? || @param_description.required
   end
 
   def required_from_path?

--- a/spec/lib/apipie/generator/swagger/method_description/response_schema_service_spec.rb
+++ b/spec/lib/apipie/generator/swagger/method_description/response_schema_service_spec.rb
@@ -56,7 +56,7 @@ describe Apipie::Generator::Swagger::MethodDescription::ResponseSchemaService do
         expect(properties).to eq(
           {
             a_number: {
-              type: 'number'
+              type: 'number', required: true
             },
             an_optional_number: {
               type: 'number'
@@ -72,7 +72,7 @@ describe Apipie::Generator::Swagger::MethodDescription::ResponseSchemaService do
           expect(properties).to eq(
             {
               a_number: {
-                type: %w[number null]
+                type: %w[number null], required: true
               },
               an_optional_number: {
                 type: %w[number null]

--- a/spec/lib/apipie/generator/swagger/param_description/builder_spec.rb
+++ b/spec/lib/apipie/generator/swagger/param_description/builder_spec.rb
@@ -78,6 +78,12 @@ describe Apipie::Generator::Swagger::ParamDescription::Builder do
 
     it { is_expected.to be_blank }
 
+    context 'when is required' do
+      let(:base_param_description_options) { { required: true } }
+
+      it { is_expected.to eq(true) }
+    end
+
     context 'when in_schema is false' do
       let(:in_schema) { false }
 
@@ -105,6 +111,14 @@ describe Apipie::Generator::Swagger::ParamDescription::Builder do
         it 'outputs an option without default warning' do
           expect { subject }.to output(/is optional but default value is not specified/).to_stderr
         end
+      end
+    end
+
+    context 'when is required' do
+      let(:base_param_description_options) { { required: true } }
+
+      it 'does not output an option without default warning' do
+        expect { subject }.not_to output(/is optional but default value is not specified/).to_stderr
       end
     end
   end

--- a/spec/lib/apipie/swagger_generator_spec.rb
+++ b/spec/lib/apipie/swagger_generator_spec.rb
@@ -61,7 +61,7 @@ describe Apipie::SwaggerGenerator do
           expect(properties).to eq(
             {
               a_number: {
-                type: 'number'
+                type: 'number', required: true
               },
               an_optional_number: {
                 type: 'number'

--- a/spec/lib/swagger/openapi_2_0_schema.json
+++ b/spec/lib/swagger/openapi_2_0_schema.json
@@ -996,7 +996,14 @@
           "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
         },
         "required": {
-          "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
+          "anyOf": [
+            {
+              "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
+            },
+            {
+              "type": "boolean"
+            }
+          ]
         },
         "enum": {
           "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"


### PR DESCRIPTION
This PR should fix the #888 issue. I'm not sure how exactly the `in_schema` is used and whether we can just ignore it in `Apipie::Generator::Swagger::ParamDescription::Builder`. But since the `in_schema` is almost always `true`, I couldn't find a way how to combine it with the `param_description` in other way.