### PR TITLE
param: Consider default_value: nil as valid config

### DIFF
--- a/lib/apipie/generator/swagger/param_description/builder.rb
+++ b/lib/apipie/generator/swagger/param_description/builder.rb
@@ -71,7 +71,7 @@ class Apipie::Generator::Swagger::ParamDescription::Builder
   end
 
   def for_default
-    return {} if @param_description.options[:default_value].blank?
+    return {} unless @param_description.options.key?(:default_value)
 
     {
       default: @param_description.options[:default_value],

--- a/spec/lib/apipie/apipies_controller_spec.rb
+++ b/spec/lib/apipie/apipies_controller_spec.rb
@@ -57,8 +57,7 @@ describe Apipie::ApipiesController, type: :controller do
     end
 
     it "succeeds on method details with the default language" do
-      allow(Apipie.configuration).to receive(:default_locale).and_return("en")
-      allow(Apipie.configuration).to receive(:languages).and_return([])
+      allow(Apipie.configuration).to receive_messages(default_locale: "en", languages: [])
 
       get :index, :params => { :version => "2.0", :resource => "architectures", :method => "index.en" }
 

--- a/spec/lib/apipie/generator/swagger/param_description/builder_spec.rb
+++ b/spec/lib/apipie/generator/swagger/param_description/builder_spec.rb
@@ -102,7 +102,7 @@ describe Apipie::Generator::Swagger::ParamDescription::Builder do
 
     subject { generated_block }
 
-    context 'required: true' do
+    context 'when required is true' do
       let(:base_param_description_options) { { required: true } }
 
       it 'does not output an option without default warning' do
@@ -112,8 +112,8 @@ describe Apipie::Generator::Swagger::ParamDescription::Builder do
       end
     end
 
-    context 'required: false' do
-      context 'no warning if default_value: nil' do
+    context 'when required is false' do
+      context 'when default_value is nil' do
         let(:base_param_description_options) do
           { required: false, default_value: nil }
         end
@@ -125,7 +125,7 @@ describe Apipie::Generator::Swagger::ParamDescription::Builder do
         end
       end
 
-      context 'no warning if default_value: 123' do
+      context 'when default_value is 123' do
         let(:base_param_description_options) do
           { required: false, default_value: 123 }
         end

--- a/spec/lib/apipie/generator/swagger/param_description/builder_spec.rb
+++ b/spec/lib/apipie/generator/swagger/param_description/builder_spec.rb
@@ -102,23 +102,49 @@ describe Apipie::Generator::Swagger::ParamDescription::Builder do
 
     subject { generated_block }
 
-    context 'when is not required' do
-      let(:base_param_description_options) { { required: false } }
-
-      context 'and no default is given' do
-        before { param_description_options.delete(:default) }
-
-        it 'outputs an option without default warning' do
-          expect { subject }.to output(/is optional but default value is not specified/).to_stderr
-        end
-      end
-    end
-
-    context 'when is required' do
+    context 'required: true' do
       let(:base_param_description_options) { { required: true } }
 
       it 'does not output an option without default warning' do
-        expect { subject }.not_to output(/is optional but default value is not specified/).to_stderr
+        expect { subject }.not_to output(
+          /is optional but default value is not specified/
+        ).to_stderr
+      end
+    end
+
+    context 'required: false' do
+      context 'no warning if default_value: nil' do
+        let(:base_param_description_options) do
+          { required: false, default_value: nil }
+        end
+
+        it 'will not warn' do
+          expect { subject }.not_to output(
+            /is optional but default value is not specified/
+          ).to_stderr
+        end
+      end
+
+      context 'no warning if default_value: 123' do
+        let(:base_param_description_options) do
+          { required: false, default_value: 123 }
+        end
+
+        it 'will not warn' do
+          expect { subject }.not_to output(
+            /is optional but default value is not specified/
+          ).to_stderr
+        end
+      end
+
+      context 'default_value not given' do
+        let(:base_param_description_options) { { required: false } }
+
+        it 'warns' do
+          expect { subject }.to output(
+            /is optional but default value is not specified/
+          ).to_stderr
+        end
       end
     end
   end


### PR DESCRIPTION
When using `param` as:
```ruby
param(:name, String, required: false, default_value: nil)
```

there would be a warning that `default_value` is missing.
This fix changes from checking `options[key].blank?` to `options.key?(key)`.
