### PR TITLE
support property example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -317,6 +317,9 @@ desc
 required
   Set this true/false to make it required/optional. Default is optional
 
+example
+  Provide the example for this parameter.
+
 allow_nil
   Setting this to true means that ``nil`` can be passed.
 
@@ -349,8 +352,8 @@ Example:
 .. code:: ruby
 
    param :user, Hash, :desc => "User info" do
-     param :username, String, :desc => "Username for login", :required => true
-     param :password, String, :desc => "Password for login", :required => true
+     param :username, String, :desc => "Username for login", :required => true, :example => 'John'
+     param :password, String, :desc => "Password for login", :required => true, :example => '1234567'
      param :membership, ["standard","premium"], :desc => "User membership"
      param :admin_override, String, :desc => "Not shown in documentation", :show => false
      param :ip_address, String, :desc => "IP address", :required => true, :missing_message => lambda { I18n.t("ip_address.required") }

--- a/lib/apipie/generator/swagger/param_description/builder.rb
+++ b/lib/apipie/generator/swagger/param_description/builder.rb
@@ -53,6 +53,7 @@ class Apipie::Generator::Swagger::ParamDescription::Builder
 
     definition.merge!(for_default)
     definition.merge!(for_required)
+    definition.merge!(for_example)
     definition.merge!(@description.to_hash) if @description.present?
 
     warn_optional_without_default_value(definition)
@@ -75,6 +76,14 @@ class Apipie::Generator::Swagger::ParamDescription::Builder
 
     {
       default: @param_description.options[:default_value],
+    }
+  end
+
+  def for_example
+    return {} unless @param_description.options.key?(:ex)
+
+    {
+      example: @param_description.options[:ex],
     }
   end
 

--- a/lib/apipie/generator/swagger/param_description/builder.rb
+++ b/lib/apipie/generator/swagger/param_description/builder.rb
@@ -83,7 +83,7 @@ class Apipie::Generator::Swagger::ParamDescription::Builder
     return {} unless @param_description.options.key?(:ex)
 
     {
-      example: @param_description.options[:ex],
+      example: @param_description.options[:example],
     }
   end
 

--- a/lib/apipie/generator/swagger/param_description/builder.rb
+++ b/lib/apipie/generator/swagger/param_description/builder.rb
@@ -80,7 +80,7 @@ class Apipie::Generator::Swagger::ParamDescription::Builder
   end
 
   def for_example
-    return {} unless @param_description.options.key?(:ex)
+    return {} unless @param_description.options.key?(:example)
 
     {
       example: @param_description.options[:example],

--- a/spec/dummy/app/controllers/pets_controller.rb
+++ b/spec/dummy/app/controllers/pets_controller.rb
@@ -23,7 +23,7 @@ class PetsController < ApplicationController
   #-----------------------------------------------------------
   api :GET, "/pets/:id/as_properties", "Get a pet record"
   returns :code => 200 do
-    property :pet_name, String, :desc => "Name of pet", :required => false, ex: 'mypet'
+    property :pet_name, String, :desc => "Name of pet", :required => false, example: 'mypet'
     property :animal_type, %w[dog cat iguana kangaroo], :desc => "Type of pet"   # required by default, because this is a 'property'
   end
   returns :code => 404 do

--- a/spec/dummy/app/controllers/pets_controller.rb
+++ b/spec/dummy/app/controllers/pets_controller.rb
@@ -23,7 +23,7 @@ class PetsController < ApplicationController
   #-----------------------------------------------------------
   api :GET, "/pets/:id/as_properties", "Get a pet record"
   returns :code => 200 do
-    property :pet_name, String, :desc => "Name of pet", :required => false
+    property :pet_name, String, :desc => "Name of pet", :required => false, ex: 'mypet'
     property :animal_type, %w[dog cat iguana kangaroo], :desc => "Type of pet"   # required by default, because this is a 'property'
   end
   returns :code => 404 do

--- a/spec/dummy/app/controllers/pets_controller.rb
+++ b/spec/dummy/app/controllers/pets_controller.rb
@@ -23,7 +23,7 @@ class PetsController < ApplicationController
   #-----------------------------------------------------------
   api :GET, "/pets/:id/as_properties", "Get a pet record"
   returns :code => 200 do
-    property :pet_name, String, :desc => "Name of pet", :required => false, example: 'mypet'
+    property :pet_name, String, :desc => "Name of pet", :required => false, :example => 'mypet'
     property :animal_type, %w[dog cat iguana kangaroo], :desc => "Type of pet"   # required by default, because this is a 'property'
   end
   returns :code => 404 do

--- a/spec/lib/apipie/generator/swagger/method_description/response_schema_service_spec.rb
+++ b/spec/lib/apipie/generator/swagger/method_description/response_schema_service_spec.rb
@@ -19,8 +19,8 @@ describe Apipie::Generator::Swagger::MethodDescription::ResponseSchemaService do
 
   let(:response_description_dsl) do
     proc do
-      property :a_number, Integer, ex: 1
-      property :an_optional_number, Integer, required: false, ex: 2
+      property :a_number, Integer, example: 1
+      property :an_optional_number, Integer, required: false, example: 2
     end
   end
 

--- a/spec/lib/apipie/generator/swagger/method_description/response_schema_service_spec.rb
+++ b/spec/lib/apipie/generator/swagger/method_description/response_schema_service_spec.rb
@@ -19,8 +19,8 @@ describe Apipie::Generator::Swagger::MethodDescription::ResponseSchemaService do
 
   let(:response_description_dsl) do
     proc do
-      property :a_number, Integer
-      property :an_optional_number, Integer, required: false
+      property :a_number, Integer, ex: 1
+      property :an_optional_number, Integer, required: false, ex: 2
     end
   end
 
@@ -56,10 +56,10 @@ describe Apipie::Generator::Swagger::MethodDescription::ResponseSchemaService do
         expect(properties).to eq(
           {
             a_number: {
-              type: 'number', required: true
+              type: 'number', required: true, example: 1
             },
             an_optional_number: {
-              type: 'number'
+              type: 'number', example: 2
             }
           }
         )
@@ -72,10 +72,10 @@ describe Apipie::Generator::Swagger::MethodDescription::ResponseSchemaService do
           expect(properties).to eq(
             {
               a_number: {
-                type: %w[number null], required: true
+                type: %w[number null], required: true, example: 1
               },
               an_optional_number: {
-                type: %w[number null]
+                type: %w[number null], example: 2
               }
             }
           )

--- a/spec/lib/apipie/generator/swagger/param_description/builder_spec.rb
+++ b/spec/lib/apipie/generator/swagger/param_description/builder_spec.rb
@@ -200,4 +200,16 @@ describe Apipie::Generator::Swagger::ParamDescription::Builder do
       it { is_expected.to be_present }
     end
   end
+
+  describe 'example' do
+    subject { generated_block[:example] }
+
+    it { is_expected.to be_blank }
+
+    context 'when example is assigned' do
+      let(:base_param_description_options) { { ex: 'example'} }
+
+      it { is_expected.to be_present }
+    end
+  end
 end

--- a/spec/lib/apipie/generator/swagger/param_description/builder_spec.rb
+++ b/spec/lib/apipie/generator/swagger/param_description/builder_spec.rb
@@ -207,7 +207,7 @@ describe Apipie::Generator::Swagger::ParamDescription::Builder do
     it { is_expected.to be_blank }
 
     context 'when example is assigned' do
-      let(:base_param_description_options) { { example: 'example'} }
+      let(:base_param_description_options) { { example: 'example' } }
 
       it { is_expected.to eq('example') }
     end

--- a/spec/lib/apipie/generator/swagger/param_description/builder_spec.rb
+++ b/spec/lib/apipie/generator/swagger/param_description/builder_spec.rb
@@ -209,7 +209,7 @@ describe Apipie::Generator::Swagger::ParamDescription::Builder do
     context 'when example is assigned' do
       let(:base_param_description_options) { { ex: 'example'} }
 
-      it { is_expected.to be_present }
+      it { is_expected.to eq('example') }
     end
   end
 end

--- a/spec/lib/apipie/generator/swagger/param_description/builder_spec.rb
+++ b/spec/lib/apipie/generator/swagger/param_description/builder_spec.rb
@@ -207,7 +207,7 @@ describe Apipie::Generator::Swagger::ParamDescription::Builder do
     it { is_expected.to be_blank }
 
     context 'when example is assigned' do
-      let(:base_param_description_options) { { ex: 'example'} }
+      let(:base_param_description_options) { { example: 'example'} }
 
       it { is_expected.to eq('example') }
     end

--- a/spec/lib/apipie/swagger_generator_spec.rb
+++ b/spec/lib/apipie/swagger_generator_spec.rb
@@ -7,7 +7,7 @@ describe Apipie::SwaggerGenerator do
 
     let(:response_description_dsl) do
       proc do
-        property :a_number, Integer, ex: 1
+        property :a_number, Integer, example: 1
         property :an_optional_number, Integer, required: false
       end
     end

--- a/spec/lib/apipie/swagger_generator_spec.rb
+++ b/spec/lib/apipie/swagger_generator_spec.rb
@@ -7,7 +7,7 @@ describe Apipie::SwaggerGenerator do
 
     let(:response_description_dsl) do
       proc do
-        property :a_number, Integer
+        property :a_number, Integer, ex: 1
         property :an_optional_number, Integer, required: false
       end
     end
@@ -61,7 +61,7 @@ describe Apipie::SwaggerGenerator do
           expect(properties).to eq(
             {
               a_number: {
-                type: 'number', required: true
+                type: 'number', required: true, example: 1
               },
               an_optional_number: {
                 type: 'number'

--- a/spec/lib/swagger/rake_swagger_spec.rb
+++ b/spec/lib/swagger/rake_swagger_spec.rb
@@ -82,6 +82,10 @@ describe 'rake tasks' do
       expect(param[field]).to eq(value)
     end
 
+    def expect_response_params_def(http_method, path, response_code, param_name, field, value)
+      param = apidoc_swagger["paths"][path][http_method]["responses"][response_code.to_s]["schema"]["properties"][param_name]
+      expect(param[field]).to eq(value)
+    end
 
     describe 'apipie:static_swagger_json[development,json,_tmp]' do
       it "generates static swagger files for the default version of apipie docs" do
@@ -105,6 +109,7 @@ describe 'rake tasks' do
                          %w[finance operations sales marketing HR])
 
         expect_tags_def("get", "/twitter_example/{id}/followers", %w[twitter_example following index search])
+        expect_response_params_def("get", "/pets/{id}/as_properties", 200, "pet_name", "example", "mypet")
       end
 
       it "generates a valid swagger file" do


### PR DESCRIPTION
[WHY]
* The generated swagger JSON didn't include the example for the response. This will be useful when the user wants to know the response example, this will help them to understand the API quicker.

[HOW]
* add a new option for the params description `ex` to provide an example for the specific parameters

Here is a swagger editor preview with the ex option, which correctly shows the example in response:
![image](https://github.com/Apipie/apipie-rails/assets/15964339/a3643041-6125-4e46-83cc-6878d1b5b104)
