### PR TITLE
Fix rubocop CI

### DIFF
--- a/.github/workflows/rubocop-challenger.yml
+++ b/.github/workflows/rubocop-challenger.yml
@@ -9,7 +9,7 @@ jobs:
     name: Create Pull Request
     runs-on: ubuntu-latest
     env:
-      BUNDLE_GEMFILE: gemfiles/Gemfile.rails50
+      RUBY_VERSION: 3.2.3
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby 3.2

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -5,6 +5,8 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      RUBY_VERSION: 3.2.3
     steps:
       - uses: actions/checkout@v3
 

--- a/spec/lib/apipie/generator/swagger/param_description/builder_spec.rb
+++ b/spec/lib/apipie/generator/swagger/param_description/builder_spec.rb
@@ -118,7 +118,7 @@ describe Apipie::Generator::Swagger::ParamDescription::Builder do
           { required: false, default_value: nil }
         end
 
-        it 'will not warn' do
+        it 'does not warn' do
           expect { subject }.not_to output(
             /is optional but default value is not specified/
           ).to_stderr
@@ -130,7 +130,7 @@ describe Apipie::Generator::Swagger::ParamDescription::Builder do
           { required: false, default_value: 123 }
         end
 
-        it 'will not warn' do
+        it 'does not warn' do
           expect { subject }.not_to output(
             /is optional but default value is not specified/
           ).to_stderr

--- a/spec/lib/swagger/swagger_dsl_spec.rb
+++ b/spec/lib/swagger/swagger_dsl_spec.rb
@@ -283,7 +283,7 @@ describe "Swagger Responses" do
         expect(schema).to have_field(:pet_id, 'number', {:description => 'id of pet'})
         expect(schema).to have_field(:pet_name, 'string', {:description => 'Name of pet', :required => false})
         expect(schema).to have_field(:animal_type, 'string', {:description => 'Type of pet', :enum => %w[dog cat iguana kangaroo]})
-        expect(schema).not_to have_field(:partial_match_allowed, 'boolean', {:required => false})
+        expect(schema).not_to have_field(:partial_match_allowed, 'boolean', {:required => false}) # rubocop:disable Capybara/NegationMatcher
       end
 
       it "creates a swagger definition with all input parameters" do


### PR DESCRIPTION
Fix rubocop workflow and rubocop-challenger workflow.

-  `gemfiles/Gemfile.rails50` is missing.  see https://github.com/Apipie/apipie-rails/actions/runs/7762735936/job/21173684766
- set `RUBY_VERSION` env on rubocop and rubocop-challenger workflow because Ruby 3.2.3 released.
- Skipped [7bc8e18](https://github.com/Apipie/apipie-rails/pull/910/commits/7bc8e18a5ac03f1534368e86b0506ce567d60191) because the expected values for the tests have changed, causing the tests to fail.
