### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ to be set are:
 -   for create action: `required => true` and `allow_nil => false`
 -   for update action: `required => false` and `allow_nil => false`
 
-This makes it hard to share the param definitions across theses actions.
+This makes it hard to share the param definitions across these actions.
 Therefore, you can make the description a bit smarter by setting
 `:action_aware => true`.
 
@@ -584,7 +584,7 @@ end
 returns :array_of => <param-group-name> [, :code => <number>|<http-response-code-symbol>] [, :desc => <human-readable description>]
 ```
 
-If the `:code` argument is ommitted, `200` is used.
+If the `:code` argument is omitted, `200` is used.
 
 ### Example
 
@@ -1573,7 +1573,7 @@ You can specify the versions for the examples, with the
 used for. When not specified, it\'s shown in all versions with the given
 method.
 
-When referencing or quering the resource/method descripion, this format
+When referencing or querying the resource/method descripion, this format
 should be used: \"version#resource#method\". When not specified, the
 default version is used instead.
 
@@ -1761,7 +1761,7 @@ the server consumes the content types
 `application/x-www-form-urlencoded` and `multipart/form-data`.
 Non-path parameters will have the value `"in": "formData"`. Note
 that parameters of type Hash that do not have any fields in them
-will *be ommitted* from the resulting files, as there is no way to
+will *be omitted* from the resulting files, as there is no way to
 describe them in swagger.
 
 - If the value is `:json` - the swagger file will indicate that the

--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -89,7 +89,7 @@ module Apipie
 
         # we create separate method description for each version in
         # case the method belongs to more versions. We return just one
-        # becuase the version doesn't matter for the purpose it's used
+        # because the version doesn't matter for the purpose it's used
         # (to wrap the original version with validators)
         ret_method_description ||= method_description
         resource_description.add_method_description(method_description)

--- a/lib/apipie/dsl_definition.rb
+++ b/lib/apipie/dsl_definition.rb
@@ -178,7 +178,7 @@ module Apipie
       alias full_description desc
 
       # describe next method with document in given path
-      # in convension, these doc located under "#{Rails.root}/doc"
+      # in convention, these doc located under "#{Rails.root}/doc"
       # Example:
       # document "hello_world.md"
       # def hello_world
@@ -452,7 +452,7 @@ module Apipie
       include Apipie::DSL::Action
       include Apipie::DSL::Param
 
-      # defines the substitutions to be made in the API paths deifned
+      # defines the substitutions to be made in the API paths defined
       # in concerns included. For example:
       #
       # There is this method defined in concern:
@@ -472,7 +472,7 @@ module Apipie
       #
       # It has to be specified before the concern is included.
       #
-      # If not specified, the default predefined substitions are
+      # If not specified, the default predefined substitutions are
       #
       #    {:conroller_path => controller.controller_path,
       #     :resource_id  => `resource_id_from_apipie` }

--- a/lib/apipie/extractor/writer.rb
+++ b/lib/apipie/extractor/writer.rb
@@ -419,7 +419,7 @@ module Apipie
       end
 
       # this method would be totally useless unless some clever guy
-      # desided that it would be great idea to change a behavior of
+      # decided that it would be great idea to change a behavior of
       # "".lines method to not include end of lines.
       #
       # For more details:

--- a/lib/apipie/param_description.rb
+++ b/lib/apipie/param_description.rb
@@ -245,7 +245,7 @@ module Apipie
 
     # makes modification that are based on the action that the param
     # is defined for. Typical for required and allow_nil variations in
-    # crate/update actions.
+    # create/update actions.
     def action_awareness
       if action_aware?
         if !@options.key?(:allow_nil)

--- a/lib/apipie/response_description_adapter.rb
+++ b/lib/apipie/response_description_adapter.rb
@@ -11,7 +11,7 @@ module Apipie
   class ResponseDescriptionAdapter
     class Modifier
       def apply(adapter)
-        raise "Modifer subclass must implement 'apply' method"
+        raise "Modifier subclass must implement 'apply' method"
       end
     end
 

--- a/lib/apipie/routes_formatter.rb
+++ b/lib/apipie/routes_formatter.rb
@@ -24,7 +24,7 @@ module Apipie
       if verb.count != 1
         verb = API_METHODS.select{|defined_verb| defined_verb == rails_route.constraints[:method]}
         if verb.blank?
-          raise "Unknow verb #{rails_route.path.spec.to_s}"
+          raise "Unknown verb #{rails_route.path.spec.to_s}"
         end
       end
       verb.first

--- a/rel-eng/gem_release.ipynb
+++ b/rel-eng/gem_release.ipynb
@@ -10,7 +10,7 @@
     "- push access to https://github.com/Apipie/apipie-rails\n",
     "- push access to rubygems.org for apipie-rails\n",
     "- sudo yum install python-slugify asciidoc\n",
-    "- ensure neither the `git push` or `gem push` don't require interractive auth. If you can't use api key or ssh key to auth skip these steps and run them form the shell manually\n",
+    "- ensure neither the `git push` or `gem push` don't require interactive auth. If you can't use api key or ssh key to auth skip these steps and run them form the shell manually\n",
     "- ensure all checks have passed on the branch you're about to release\n",
     "\n",
     "### Release process\n",
@@ -117,7 +117,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Run tests localy if your setup allows, otherwise ensure the HEAD is green"
+    "### Run tests locally if your setup allows, otherwise ensure the HEAD is green"
    ]
   },
   {
@@ -217,14 +217,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Manual step: Update deps in the gemspec if neccessary"
+    "#### Manual step: Update deps in the gemspec if necessary"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Check what is going to be commited"
+    "### Check what is going to be committed"
    ]
   },
   {
@@ -347,7 +347,7 @@
    "source": [
     "### Some manual steps follow to improve the UX\n",
     "\n",
-    "#### New relase on GitHub\n",
+    "#### New release on GitHub\n",
     "\n",
     "Copy the following changelog lines to the description in form on link below\n",
     "The release title is the new version."

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -430,7 +430,7 @@ describe UsersController do
       expect(b.full_description.length).to be > 400
     end
 
-    context "Usign routes.rb" do
+    context "Using routes.rb" do
       it "should contain basic info about method" do
         a = Apipie[UsersController, :create_route]
         expect(a.apis.count).to eq(1)

--- a/spec/dummy/app/controllers/api/v2/empty_middle_controller.rb
+++ b/spec/dummy/app/controllers/api/v2/empty_middle_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V2
     class EmptyMiddleController < V2::BaseController
       # This is an empty controller, used to test cases where controllers
-      # may inherit from a middle controler that does not define a resource_description,
+      # may inherit from a middle controller that does not define a resource_description,
       # but the middle controller's parent does.
 
       def inconsequential_method

--- a/spec/dummy/app/controllers/pets_controller.rb
+++ b/spec/dummy/app/controllers/pets_controller.rb
@@ -63,7 +63,7 @@ class PetsController < ApplicationController
   # mixing request/response and response-only parameters
   #
   # the param_group :pet_with_id has several parameters which are
-  # not expectd in the request, but would show up in the response
+  # not expected in the request, but would show up in the response
   # and vice versa
   #-----------------------------------------------------------
   def_param_group :pet_with_id do

--- a/spec/dummy/app/controllers/twitter_example_controller.rb
+++ b/spec/dummy/app/controllers/twitter_example_controller.rb
@@ -10,7 +10,7 @@ class TwitterExampleController < ApplicationController
   api :GET, '/twitter_example/lookup', 'Return up to 100 users worth of extended information, specified by either ID, screen name, or combination of the two.'
   param :screen_name, String, :desc => 'A comma separated list of screen names, up to 100 are allowed in a single request. You are strongly encouraged to use a POST for larger (up to 100 screen names) requests.'
   param :user_id, Integer, :desc => 'A comma separated list of user IDs, up to 100 are allowed in a single request. You are strongly encouraged to use a POST for larger requests.'
-  param :include_entities, String, :desc => 'When set to either <code>true</code>, <code>t</code> or <code>1</code>, each tweet will include a node called "entities,". This node offers a variety of metadata about the tweet in a discreet structure, including: user_mentions, urls, and hashtags. While entities are opt-in on timelines at present, they will be made a default component of output in the future. See Tweet Entities for more detail on entities.'
+  param :include_entities, String, :desc => 'When set to either <code>true</code>, <code>t</code> or <code>1</code>, each tweet will include a node called "entities,". This node offers a variety of metadata about the tweet in a discrete structure, including: user_mentions, urls, and hashtags. While entities are opt-in on timelines at present, they will be made a default component of output in the future. See Tweet Entities for more detail on entities.'
   
   description <<-EOS
     Return up to 100 users worth of extended information, specified by either ID, screen name, or combination of the two. The author's most recent status (if the authenticating user has permission) will be returned inline.
@@ -53,8 +53,8 @@ class TwitterExampleController < ApplicationController
   api :GET, '/twitter_example/search', 'Runs a search for users similar to Find People button on Twitter.com.'
   param :q, String, :desc => 'The search query to run against people search.', :required => true
   param :page, Integer, :desc => 'Specifies the page of results to retrieve.'
-  param :per_page, Integer, :desc => 'The number of people to retrieve. Maxiumum of 20 allowed per page.'
-  param :include_entities, String, :desc => 'When set to either true, t or 1, each tweet will include a node called "entities,". This node offers a variety of metadata about the tweet in a discreet structure, including: user_mentions, urls, and hashtags. While entities are opt-in on timelines at present, they will be made a default component of output in the future. See Tweet Entities for more detail on entities.'
+  param :per_page, Integer, :desc => 'The number of people to retrieve. Maximum of 20 allowed per page.'
+  param :include_entities, String, :desc => 'When set to either true, t or 1, each tweet will include a node called "entities,". This node offers a variety of metadata about the tweet in a discrete structure, including: user_mentions, urls, and hashtags. While entities are opt-in on timelines at present, they will be made a default component of output in the future. See Tweet Entities for more detail on entities.'
   description <<-EOS
     Runs a search for users similar to Find People button on Twitter.com. The results returned by people search on Twitter.com are the same as those returned by this API request. Note that unlike GET search, this method does not support any operators.
 

--- a/spec/lib/apipie/apipies_controller_spec.rb
+++ b/spec/lib/apipie/apipies_controller_spec.rb
@@ -188,7 +188,7 @@ describe Apipie::ApipiesController, type: :controller do
 
 
   describe "authenticate user" do
-    it "authenticate user if an authentication method is setted" do
+    it "authenticate user if an authentication method is set" do
       test = false
       Apipie.configuration.authenticate = Proc.new do
         test = true

--- a/spec/lib/apipie/file_handler_spec.rb
+++ b/spec/lib/apipie/file_handler_spec.rb
@@ -15,7 +15,7 @@ describe Apipie::FileHandler do
       it { expect { file_handler.match? path }.to_not raise_error }
     end
 
-    context 'when the path contans an invalid byte sequence in UTF-8' do
+    context 'when the path contains an invalid byte sequence in UTF-8' do
       let(:path) { "%B6" }
 
       it { expect(file_handler.match? path).to be_falsy }

--- a/spec/lib/apipie/param_description_spec.rb
+++ b/spec/lib/apipie/param_description_spec.rb
@@ -21,7 +21,7 @@ describe Apipie::ParamDescription do
 
     it "should return the metadata" do
       meta = {
-        :lenght => 32,
+        :length => 32,
         :weight => '830g'
       }
       param = Apipie::ParamDescription.new(method_desc, :some_param, String, :meta => meta)


### PR DESCRIPTION
Found via `codespell -S config,CHANGELOG.md -L
isnt,splitted,childs,xdescribe`