### PR TITLE
"allow_blank" setting is not displayed in api doc

### DIFF
--- a/app/views/apipie/apipies/_params.html.erb
+++ b/app/views/apipie/apipies/_params.html.erb
@@ -15,6 +15,7 @@
       <small>
         <%= param[:required] ? t('apipie.required') : t('apipie.optional') %>
         <%= param[:allow_nil] ? ', '+t('apipie.nil_allowed') : '' %>
+        <%= param[:allow_blank] ? ', '+t('apipie.blank_allowed') : '' %>
       </small>
     </td>
     <td>

--- a/app/views/apipie/apipies/_params_plain.html.erb
+++ b/app/views/apipie/apipies/_params_plain.html.erb
@@ -9,6 +9,7 @@
       <small>
         <%= param[:required] ? t('apipie.required') : t('apipie.optional') %>
         <%= param[:allow_nil] ? ', '+t('apipie.nil_allowed') : '' %>
+        <%= param[:allow_blank] ? ', '+t('apipie.blank_allowed') : '' %>
         <% if param[:validator] %>
           [ <%= Apipie.markup_to_html(param[:validator]).html_safe %> ]
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,7 @@ en:
     required: required
     optional: optional
     nil_allowed: nil allowed
+    blank_allowed: blank allowed
     param_name: Param name
     params: Params
     examples: Examples

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -15,6 +15,7 @@ ko:
     required: 필수
     optional: 옵션
     nil_allowed: nil 허용
+    blank_allowed: blank 허용
     param_name: Param 이름
     params: Params
     examples: 예시


### PR DESCRIPTION
#925  

"allow_blank" setting is not displayed in api doc

i added blank allowed message
