### PR TITLE
Support for Ruby 3.4.0-preview1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ jobs:
         rails: ["7.1", "7.0", "6.1", "6.0"]
         ruby: ["3.3", "3.2", "3.1", "3.0", "2.7"]
         include:
+          - rails: "7.1"
+            ruby: "3.4.0-preview1"
           - rails: "5.2"
             ruby: "2.7.8"
           - rails: "5.1"

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ source 'https://rubygems.org'
 gemspec path: '.'
 
 # use ENV vars, with default value as fallback for local setup
-gem 'actionpack', "~> #{ENV['RAILS_VERSION'] || '7.0'}.0"
-gem 'activesupport', "~> #{ENV['RAILS_VERSION'] || '7.0'}.0"
+gem 'actionpack', "~> #{ENV['RAILS_VERSION'] || RUBY_VERSION >= '3.4' ? '7.1' : '7.0'}.0"
+gem 'activesupport', "~> #{ENV['RAILS_VERSION'] || RUBY_VERSION >= '3.4' ? '7.1' : '7.0'}.0"
 
 gem 'mime-types' # , '~> 3.0'
 gem 'rails-controller-testing'

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ source 'https://rubygems.org'
 gemspec path: '.'
 
 # use ENV vars, with default value as fallback for local setup
-gem 'actionpack', "~> #{ENV['RAILS_VERSION'] || RUBY_VERSION >= '3.4' ? '7.1' : '7.0'}.0"
-gem 'activesupport', "~> #{ENV['RAILS_VERSION'] || RUBY_VERSION >= '3.4' ? '7.1' : '7.0'}.0"
+gem 'actionpack', "~> #{ENV['RAILS_VERSION'] || '7.1'}.0"
+gem 'activesupport', "~> #{ENV['RAILS_VERSION'] || '7.1'}.0"
 
 gem 'mime-types' # , '~> 3.0'
 gem 'rails-controller-testing'


### PR DESCRIPTION
This Pull Request adds support for Ruby 3.4.0-preview1.  Running the current code with Ruby 3.4.0-preview1 results in the following error:

```sh
An error occurred while loading ./spec/lib/validators/array_validator_spec.rb. - Did you mean?
                    rspec ./spec/lib/apipie/validator_spec.rb

Failure/Error: require "action_controller/railtie"

LoadError:
  cannot load such file -- bigdecimal
# ./spec/dummy/config/application.rb:3:in '<top (required)>'
# ./spec/dummy/config/environment.rb:5:in '<top (required)>'
# ./spec/spec_helper.rb:10:in '<top (required)>'
# ./spec/lib/validators/array_validator_spec.rb:1:in '<top (required)>'
```

The reason for this error is that in Rails 7.0.X, bigdecimal is not added to the Gemfile (ref: [Rails PR #49039](https://github.com/rails/rails/pull/49039)). Therefore, for Ruby 3.4 and above, we need to use Rails 7.1.X for testing.