### PR TITLE
PAT-371: Upgrade Monolith Ruby version to Latest Stable

### DIFF
--- a/lib/apipie/extractor/recorder.rb
+++ b/lib/apipie/extractor/recorder.rb
@@ -150,8 +150,8 @@ module Apipie
       end
 
       module FunctionalTestRecording
-        def process(*args) # action, parameters = nil, session = nil, flash = nil, http_method = 'GET')
-          ret = super(*args)
+        def process(*) # action, parameters = nil, session = nil, flash = nil, http_method = 'GET')
+          ret = super
           if Apipie.configuration.record
             Apipie::Extractor.call_recorder.analyze_functional_test(self)
             Apipie::Extractor.call_finished
@@ -160,6 +160,8 @@ module Apipie
         ensure
           Apipie::Extractor.clean_call_recorder
         end
+        # Taking this from https://github.com/Apipie/apipie-rails/blob/master/lib/apipie/extractor/recorder.rb#L189C1-L190C1
+        ruby2_keywords :process if respond_to?(:ruby2_keywords, true)
       end
     end
   end

--- a/lib/apipie/markup.rb
+++ b/lib/apipie/markup.rb
@@ -4,20 +4,23 @@ module Apipie
 
     class RDoc
 
-      def initialize
-        require 'rdoc'
-        require 'rdoc/markup/to_html'
-        if Gem::Version.new(::RDoc::VERSION) < Gem::Version.new('4.0.0')
-          @rdoc ||= ::RDoc::Markup::ToHtml.new()
-        else
-          @rdoc ||= ::RDoc::Markup::ToHtml.new(::RDoc::Options.new)
+      def to_html(text)
+        rdoc.convert(text)
+      end
+
+      private
+
+      def rdoc
+        @rdoc ||= begin
+          require 'rdoc'
+          require 'rdoc/markup/to_html'
+          if Gem::Version.new(::RDoc::VERSION) < Gem::Version.new('4.0.0')
+            ::RDoc::Markup::ToHtml.new()
+          else
+            ::RDoc::Markup::ToHtml.new(::RDoc::Options.new)
+          end
         end
       end
-
-      def to_html(text)
-        @rdoc.convert(text)
-      end
-
     end
 
     class Markdown


### PR DESCRIPTION
After updating this, I was able to fix the controller specs

```
gtrujillop:~/bse/path-lms (ruby-3.0.7) [PAT-371-ruby-upgrade] $ bundle exec rspec ./spec/foundational/controllers/lock_users_controller_spec.rb
warning: parser/current is loading parser/ruby30, which recognizes 3.0.6-compliant syntax, but you are running 3.0.7.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
/home/gtrujillop/bse/path-lms/config/initializers/sidekiq.rb:52: warning: Sidekiq's Delayed Extensions will be removed in Sidekiq 7.0
WARNING: `around(:context)` hooks are not supported and behave like `around(:example). Called from /home/gtrujillop/bse/path-lms/spec/spec_helper.rb:320:in `block in <top (required)>'.

Randomized with seed 42260

.........

Finished in 3.07 seconds (files took 23.59 seconds to load)
19 examples, 0 failures

Randomized with seed 42260

Coverage report generated for RSpec to /home/gtrujillop/bse/path-lms/coverage. 35032 / 87350 LOC (40.11%) covered.
gtrujillop:~/bse/path-lms (ruby-3.0.7) [PAT-371-ruby-upgrade] $ 
```