### PR TITLE
Fix error for hash object warnings with delegated method descriptions

### DIFF
--- a/lib/apipie/generator/swagger/param_description/builder.rb
+++ b/lib/apipie/generator/swagger/param_description/builder.rb
@@ -1,7 +1,7 @@
 class Apipie::Generator::Swagger::ParamDescription::Builder
   # @param [Apipie::ParamDescription] param_description
   # @param [TrueClass, FalseClass] in_schema
-  # @param [Apipie::MethodDescription] controller_method
+  # @param [Apipie::MethodDescription, nil] controller_method
   def initialize(param_description, in_schema:, controller_method:)
     @param_description = param_description
     @in_schema = in_schema
@@ -98,7 +98,7 @@ class Apipie::Generator::Swagger::ParamDescription::Builder
   def warn_optional_without_default_value(definition)
     if !required? && !definition.key?(:default)
       method_id =
-        if @param_description.is_a?(Apipie::ResponseDescriptionAdapter::PropDesc)
+        if @controller_method.present? && @param_description.is_a?(Apipie::ResponseDescriptionAdapter::PropDesc)
           @controller_method.method_name
         else
           Apipie::Generator::Swagger::MethodDescription::Decorator.new(@controller_method).ruby_name

--- a/lib/apipie/generator/swagger/param_description/builder.rb
+++ b/lib/apipie/generator/swagger/param_description/builder.rb
@@ -99,7 +99,7 @@ class Apipie::Generator::Swagger::ParamDescription::Builder
     if !required? && !definition.key?(:default)
       method_id =
         if @param_description.is_a?(Apipie::ResponseDescriptionAdapter::PropDesc)
-          @controller_method
+          @controller_method.method_name
         else
           Apipie::Generator::Swagger::MethodDescription::Decorator.new(@controller_method).ruby_name
         end

--- a/lib/apipie/generator/swagger/param_description/type.rb
+++ b/lib/apipie/generator/swagger/param_description/type.rb
@@ -114,7 +114,7 @@ class Apipie::Generator::Swagger::ParamDescription::Type
   def warn_hash_without_internal_typespec
     method_id =
       if @param_description.is_a?(Apipie::ResponseDescriptionAdapter::PropDesc)
-        @controller_method.method
+        @controller_method.method_name
       else
         Apipie::Generator::Swagger::MethodDescription::Decorator.new(@param_description.method_description).ruby_name
       end

--- a/lib/apipie/generator/swagger/param_description/type.rb
+++ b/lib/apipie/generator/swagger/param_description/type.rb
@@ -114,7 +114,11 @@ class Apipie::Generator::Swagger::ParamDescription::Type
   def warn_hash_without_internal_typespec
     method_id =
       if @param_description.is_a?(Apipie::ResponseDescriptionAdapter::PropDesc)
-        @controller_method.method_name
+        if @controller_method.present?
+          @controller_method.method_name
+        else
+          Apipie::Generator::Swagger::MethodDescription::Decorator.new(nil).ruby_name
+        end
       else
         Apipie::Generator::Swagger::MethodDescription::Decorator.new(@param_description.method_description).ruby_name
       end

--- a/spec/lib/apipie/generator/swagger/param_description/builder_spec.rb
+++ b/spec/lib/apipie/generator/swagger/param_description/builder_spec.rb
@@ -145,6 +145,24 @@ describe Apipie::Generator::Swagger::ParamDescription::Builder do
             /is optional but default value is not specified/
           ).to_stderr
         end
+
+        context 'and param is a prop desc with a delegated controller method' do
+          let(:param_description) do
+            Apipie.prop(:param, 'object', param_description_options, [])
+          end
+
+          let(:method_desc) do
+            Apipie::Generator::Swagger::MethodDescription::Decorator.new(
+              Apipie::MethodDescription.new(:show, resource_desc, dsl_data)
+            )
+          end
+
+          it 'warns' do
+            expect { subject }.to output(
+              /is optional but default value is not specified/
+            ).to_stderr
+          end
+        end
       end
     end
   end

--- a/spec/lib/apipie/generator/swagger/param_description/builder_spec.rb
+++ b/spec/lib/apipie/generator/swagger/param_description/builder_spec.rb
@@ -146,21 +146,33 @@ describe Apipie::Generator::Swagger::ParamDescription::Builder do
           ).to_stderr
         end
 
-        context 'and param is a prop desc with a delegated controller method' do
+        context 'and param is a prop desc' do
           let(:param_description) do
             Apipie.prop(:param, 'object', param_description_options, [])
           end
 
-          let(:method_desc) do
-            Apipie::Generator::Swagger::MethodDescription::Decorator.new(
-              Apipie::MethodDescription.new(:show, resource_desc, dsl_data)
-            )
+          context 'with a delegated controller method' do
+            let(:method_desc) do
+              Apipie::Generator::Swagger::MethodDescription::Decorator.new(
+                Apipie::MethodDescription.new(:show, resource_desc, dsl_data)
+              )
+            end
+
+            it 'warns' do
+              expect { subject }.to output(
+                /is optional but default value is not specified/
+              ).to_stderr
+            end
           end
 
-          it 'warns' do
-            expect { subject }.to output(
-              /is optional but default value is not specified/
-            ).to_stderr
+          context 'with a nil controller method' do
+            let(:method_desc) { nil }
+
+            it 'warns' do
+              expect { subject }.to output(
+                /is optional but default value is not specified/
+              ).to_stderr
+            end
           end
         end
       end

--- a/spec/lib/apipie/generator/swagger/param_description/type_spec.rb
+++ b/spec/lib/apipie/generator/swagger/param_description/type_spec.rb
@@ -63,9 +63,11 @@ describe Apipie::Generator::Swagger::ParamDescription::Type do
     )
   end
 
+  let(:controller_method) { 'index' }
+
   let(:type_definition) do
     described_class.
-      new(param_description, with_null: with_null, controller_method: 'index').
+      new(param_description, with_null: with_null, controller_method: controller_method).
       to_hash
   end
 
@@ -177,6 +179,22 @@ describe Apipie::Generator::Swagger::ParamDescription::Type do
 
       it 'outputs a hash without internal typespec warning' do
         expect { subject }.to output(/is a generic Hash without an internal type specification/).to_stderr
+      end
+
+      context 'and param is a prop desc with a delegated controller method' do
+        let(:param_description) do
+          Apipie.prop(param_description_name, 'object', {}, [])
+        end
+
+        let(:controller_method) do
+          Apipie::Generator::Swagger::MethodDescription::Decorator.new(
+            method_desc
+          )
+        end
+
+        it 'outputs a hash without internal typespec warning' do
+          expect { subject }.to output(/is a generic Hash without an internal type specification/).to_stderr
+        end
       end
     end
   end

--- a/spec/lib/apipie/generator/swagger/param_description/type_spec.rb
+++ b/spec/lib/apipie/generator/swagger/param_description/type_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe Apipie::Generator::Swagger::ParamDescription::Type do
   let(:validator_options) { {} }
   let(:param_description_options) { {}.merge(validator_options) }
-  let(:with_null) { false }
   let(:http_method) { :GET }
   let(:path) { '/api' }
   let(:validator) { String }
@@ -67,7 +66,7 @@ describe Apipie::Generator::Swagger::ParamDescription::Type do
 
   let(:type_definition) do
     described_class.
-      new(param_description, with_null: with_null, controller_method: controller_method).
+      new(param_description, with_null: false, controller_method: controller_method).
       to_hash
   end
 

--- a/spec/lib/apipie/generator/swagger/param_description/type_spec.rb
+++ b/spec/lib/apipie/generator/swagger/param_description/type_spec.rb
@@ -180,19 +180,29 @@ describe Apipie::Generator::Swagger::ParamDescription::Type do
         expect { subject }.to output(/is a generic Hash without an internal type specification/).to_stderr
       end
 
-      context 'and param is a prop desc with a delegated controller method' do
+      context 'and param is a prop desc' do
         let(:param_description) do
           Apipie.prop(param_description_name, 'object', {}, [])
         end
 
-        let(:controller_method) do
-          Apipie::Generator::Swagger::MethodDescription::Decorator.new(
-            method_desc
-          )
+        context 'with a delegated controller method' do
+          let(:controller_method) do
+            Apipie::Generator::Swagger::MethodDescription::Decorator.new(
+              method_desc
+            )
+          end
+
+          it 'outputs a hash without internal typespec warning' do
+            expect { subject }.to output(/is a generic Hash without an internal type specification/).to_stderr
+          end
         end
 
-        it 'outputs a hash without internal typespec warning' do
-          expect { subject }.to output(/is a generic Hash without an internal type specification/).to_stderr
+        context 'and controller method is nil' do
+          let(:controller_method) { nil }
+
+          it 'outputs a hash without internal typespec warning' do
+            expect { subject }.to output(/is a generic Hash without an internal type specification/).to_stderr
+          end
         end
       end
     end


### PR DESCRIPTION
Fix how we generate warnings about params or properties defined as Hashes without defining what keys they can have inside them.

Our swagger docs stopped working with an ArgumentError:

    ArgumentError: wrong number of arguments (given 0, expected 1)

And it turns out it was in the `Apipie::Generator::Swagger::ParamDescription::Type#warn_hash_without_internal_typespec` method where we call `@controller_method.method` and `@controller_method` was a `Apipie::Generator::Swagger::MethodDescription::Decorator` instance instead of a `Apipie::MethodDescription` instance.  The `Decorator` is a `SimpleDelegator` onto a `MethodDescription` so it _should_ be able to call `method` with no arguments, but it turns out that `SimpleDelegator` won't delegate `method` because it keeps it to refer to `Object#method`.  In #865 we introduced the `method_name` method on `MethodDescription` to address this very problem, but we didn't actually use it in all the places we needed to. This PR fixes that in `warn_hash_without_internal_typespec` where my code was breaking and in `Apipie::Generator::Swagger::ParamDescription::Builder#warn_optional_without_default_value` where we weren't trying to call `method` but we probably should have been.  The error here was getting `#<Apipie::MethodDescription:0x0000000126316f60>` in log messages when we'd rather get the method name.

See https://github.com/Apipie/apipie-rails/pull/939 for some commits in this PR that should be merged separately - they're about a set of fixes that get us to a green build on modern ruby, rack, rubocop infrastructure.  For now, focus on the "Use `method_name`..." commits in this PR.