### PR TITLE
Get the build green for modern ruby and rack and rubocop-rspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 require:
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-rspec_rails
   - rubocop-performance
 
 inherit_from: .rubocop_todo.yml

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1155,7 +1155,7 @@ RSpec/PredicateMatcher:
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: Inferences.
-RSpec/Rails/InferredSpecType:
+RSpecRails/InferredSpecType:
   Exclude:
     - 'spec/controllers/pets_controller_spec.rb'
 

--- a/apipie-rails.gemspec
+++ b/apipie-rails.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop-rails'
   s.add_development_dependency 'rubocop-rspec'
   s.add_development_dependency 'rubocop-performance'
+  s.add_development_dependency 'rubocop-rspec_rails'
   s.add_development_dependency "simplecov"
   s.add_development_dependency "sqlite3"
 end

--- a/lib/apipie/error_description.rb
+++ b/lib/apipie/error_description.rb
@@ -17,9 +17,13 @@ module Apipie
         @metadata = code_or_options[:meta]
         @description = code_or_options[:desc] || code_or_options[:description]
       else
-        @code = 
+        @code =
           if code_or_options.is_a? Symbol
-            Rack::Utils::SYMBOL_TO_STATUS_CODE[code_or_options]
+            begin
+              Rack::Utils.status_code(code_or_options)
+            rescue ArgumentError
+              nil
+            end
           else
             code_or_options
           end

--- a/lib/apipie/extractor/recorder.rb
+++ b/lib/apipie/extractor/recorder.rb
@@ -14,12 +14,12 @@ module Apipie
         @params = Rack::Utils.parse_nested_query(@query)
         @params.merge!(env["action_dispatch.request.request_parameters"] || {})
         rack_input = env["rack.input"]
-        if data = parse_data(rack_input.read)
+        if data = parse_data(rack_input&.read)
           @request_data = data
         elsif form_hash = env["rack.request.form_hash"]
           @request_data = reformat_multipart_data(form_hash)
         end
-        rack_input.rewind
+        rack_input&.rewind
       end
 
       def analyse_controller(controller)

--- a/lib/apipie/response_description.rb
+++ b/lib/apipie/response_description.rb
@@ -88,11 +88,16 @@ module Apipie
 
       @method_description = method_description
 
-      if code.is_a? Symbol
-        @code = Rack::Utils::SYMBOL_TO_STATUS_CODE[code]
-      else
-        @code = code
-      end
+      @code =
+        if code.is_a? Symbol
+          begin
+            Rack::Utils.status_code(code)
+          rescue ArgumentError
+            nil
+          end
+        else
+          code
+        end
 
       @description = options[:desc]
       if @description.nil?

--- a/spec/lib/swagger/swagger_dsl_spec.rb
+++ b/spec/lib/swagger/swagger_dsl_spec.rb
@@ -283,7 +283,7 @@ describe "Swagger Responses" do
         expect(schema).to have_field(:pet_id, 'number', {:description => 'id of pet'})
         expect(schema).to have_field(:pet_name, 'string', {:description => 'Name of pet', :required => false})
         expect(schema).to have_field(:animal_type, 'string', {:description => 'Type of pet', :enum => %w[dog cat iguana kangaroo]})
-        expect(schema).not_to have_field(:partial_match_allowed, 'boolean', {:required => false}) # rubocop:disable Capybara/NegationMatcher
+        expect(schema).not_to have_field(:partial_match_allowed, 'boolean', {:required => false})
       end
 
       it "creates a swagger definition with all input parameters" do


### PR DESCRIPTION
Separated out from #938 this PR attempts to get the master build to green from a fresh checkout.

These days you're probably on ruby 3.x and will get rack 3.x and rubocop-rspec 3.x too.  These new versions all cause problems with the code in master, so the build won't pass.

1.  https://github.com/rack/rack/pull/2137 - Handle the fact that the values in `Rack::Utils::SYMBOL_TO_STATUS_CODE` are now different and this causes the dummy rails app we use for testing to not load and this blocks the entire suite from running.  The solution is to use `Rack::Utils.status_code` which has a workaround for the old names.
2. https://github.com/rack/rack/pull/2018 - Handle the fact that `rack.input` is now optional in the rack env. The solution is to use safe navigation to call the methods we wanted.
3. https://github.com/rubocop/rubocop-rspec/pull/1848 - Introduce `rubocop-rspec_rails` as the cops it provides were extracted from `rubocop-rspec` and our config in `rubocop_todo.yml` referenced them and rubocop doesn't like config for cops it doesn't know about so that blocked the build.
4. Fix the one rubocop offence that being able to run the build again let us see.