### PR TITLE
Rename render_page in apipie.rake to render_apipie_page

### DIFF
--- a/lib/tasks/apipie.rake
+++ b/lib/tasks/apipie.rake
@@ -182,7 +182,7 @@ namespace :apipie do
     return @apipie_renderer
   end
 
-  def render_page(file_name, template, variables, layout = 'apipie')
+  def render_apipie_page(file_name, template, variables, layout = 'apipie')
     av = renderer
     File.open(file_name, "w") do |f|
       variables.each do |var, val|
@@ -238,21 +238,21 @@ namespace :apipie do
   def generate_one_page(file_base, doc, lang = nil)
     FileUtils.mkdir_p(File.dirname(file_base)) unless File.exist?(File.dirname(file_base))
 
-    render_page("#{file_base}-onepage#{lang_ext(lang)}.html", "static", {:doc => doc[:docs],
+    render_apipie_page("#{file_base}-onepage#{lang_ext(lang)}.html", "static", {:doc => doc[:docs],
       :language => lang, :languages => Apipie.configuration.languages})
   end
 
   def generate_plain_page(file_base, doc, lang = nil)
     FileUtils.mkdir_p(File.dirname(file_base)) unless File.exist?(File.dirname(file_base))
 
-    render_page("#{file_base}-plain#{lang_ext(lang)}.html", "plain", {:doc => doc[:docs],
+    render_apipie_page("#{file_base}-plain#{lang_ext(lang)}.html", "plain", {:doc => doc[:docs],
       :language => lang, :languages => Apipie.configuration.languages}, nil)
   end
 
   def generate_index_page(file_base, doc, include_json = false, show_versions = false, lang = nil)
     FileUtils.mkdir_p(File.dirname(file_base)) unless File.exist?(File.dirname(file_base))
     versions = show_versions && Apipie.available_versions
-    render_page("#{file_base}#{lang_ext(lang)}.html", "index", {:doc => doc[:docs],
+    render_apipie_page("#{file_base}#{lang_ext(lang)}.html", "index", {:doc => doc[:docs],
       :versions => versions, :language => lang, :languages => Apipie.configuration.languages})
 
     File.open("#{file_base}#{lang_ext(lang)}.json", "w") { |f| f << doc.to_json } if include_json
@@ -265,7 +265,7 @@ namespace :apipie do
 
       doc = Apipie.to_json(version, resource_id, nil, lang)
       doc[:docs][:link_extension] = (lang ? ".#{lang}.html" : ".html")
-      render_page("#{resource_file_base}#{lang_ext(lang)}.html", "resource", {:doc => doc[:docs],
+      render_apipie_page("#{resource_file_base}#{lang_ext(lang)}.html", "resource", {:doc => doc[:docs],
         :resource => doc[:docs][:resources].first, :language => lang, :languages => Apipie.configuration.languages})
       File.open("#{resource_file_base}#{lang_ext(lang)}.json", "w") { |f| f << doc.to_json } if include_json
     end
@@ -279,7 +279,7 @@ namespace :apipie do
 
         doc = Apipie.to_json(version, resource_id, method[:name], lang)
         doc[:docs][:link_extension] = (lang ? ".#{lang}.html" : ".html")
-        render_page("#{method_file_base}#{lang_ext(lang)}.html", "method", {:doc => doc[:docs],
+        render_apipie_page("#{method_file_base}#{lang_ext(lang)}.html", "method", {:doc => doc[:docs],
                                                            :resource => doc[:docs][:resources].first,
                                                            :method => doc[:docs][:resources].first[:methods].first,
                                                            :language => lang,


### PR DESCRIPTION
We tried to integrate this project this week but ran into a very specific issue. We have a field called `render_page` on one of our models. And we're using [factory_bot](https://github.com/thoughtbot/factory_bot) to build factories for our tests. Inside our factory we're calling a `render_page` function to set up the data for the initial value. (i.e.)

```ruby
FactoryBot.define do
  factory :my_model do
    render_page { "the_page" }
  end
end
```

As soon as we add `apipie-rails` to the Gemfile like this it starts failing.

```
gem "apipie-rails"
```

Example output

```
NoMethodError: undefined method `namespace' for module Apipie (NoMethodError)
/Users/person/Source/project/packs/docs/config/initializers/apipie.rb:35:in `<module:Apipie>'
/Users/person/Source/project/packs/docs/config/initializers/apipie.rb:34:in `<main>'
/Users/person/Source/project/config/environment.rb:5:in `<main>'
Tasks: TOP => tailwindcss:build => environment
```

I tracked it down to the fact that there is a function in `apipie.rake` that is aparantly existing in the global namespace and it's trying to call this function instead. I just renamed it to be very specific to apipie and I no longer have this issue.