### PR TITLE
don't collect records without an action

### DIFF
--- a/lib/apipie/extractor/collector.rb
+++ b/lib/apipie/extractor/collector.rb
@@ -18,6 +18,7 @@ module Apipie
 
       def ignore_call?(record)
         return true unless record[:controller]
+        return true unless record[:action]
         return true if @ignored.include?(record[:controller].name)
         return true if @ignored.include?("#{Apipie.get_resource_id(record[:controller].name)}##{record[:action]}")
         return true unless @api_controllers_paths.include?(controller_full_path(record[:controller]))

--- a/spec/lib/apipie/extractor/collector_spec.rb
+++ b/spec/lib/apipie/extractor/collector_spec.rb
@@ -10,7 +10,13 @@ describe Apipie::Extractor::Collector do
 
     let(:record) { { controller: controller, action: action } }
     let(:controller) { ActionController::Base }
-    let(:action) { nil }
+    let(:action) { 'index' }
+
+    context 'when action is nil' do
+      let(:action) { nil }
+
+      it { is_expected.to be true }
+    end
 
     context 'when controller is nil' do
       let(:controller) { nil }


### PR DESCRIPTION
sometimes the collector gets called with `:action => nil`, e.g. when the originating request failed and Rails returned an error *before* identifying which action would have been executed.

this breaks the writer with the following error:

    /home/runner/work/foreman/foreman/vendor/bundle/ruby/2.7.0/gems/apipie-rails-1.4.2/lib/apipie/application.rb:234:in `block in get_method_descriptions': undefined method `to_sym' for nil:NilClass (NoMethodError)
    Did you mean?  to_m
    	from /home/runner/work/foreman/foreman/vendor/bundle/ruby/2.7.0/gems/apipie-rails-1.4.2/lib/apipie/application.rb:233:in `map'
    	from /home/runner/work/foreman/foreman/vendor/bundle/ruby/2.7.0/gems/apipie-rails-1.4.2/lib/apipie/application.rb:233:in `get_method_descriptions'
    	from /home/runner/work/foreman/foreman/vendor/bundle/ruby/2.7.0/gems/apipie-rails-1.4.2/lib/apipie/apipie_module.rb:34:in `method_missing'
    	from /home/runner/work/foreman/foreman/vendor/bundle/ruby/2.7.0/gems/apipie-rails-1.4.2/lib/apipie/extractor/writer.rb:175:in `block (2 levels) in load_new_examples'
    	from /home/runner/work/foreman/foreman/vendor/bundle/ruby/2.7.0/gems/apipie-rails-1.4.2/lib/apipie/extractor/writer.rb:174:in `map'
    	from /home/runner/work/foreman/foreman/vendor/bundle/ruby/2.7.0/gems/apipie-rails-1.4.2/lib/apipie/extractor/writer.rb:174:in `block in load_new_examples'
    	from /home/runner/work/foreman/foreman/vendor/bundle/ruby/2.7.0/gems/apipie-rails-1.4.2/lib/apipie/extractor/writer.rb:171:in `each'
    	from /home/runner/work/foreman/foreman/vendor/bundle/ruby/2.7.0/gems/apipie-rails-1.4.2/lib/apipie/extractor/writer.rb:171:in `reduce'
    	from /home/runner/work/foreman/foreman/vendor/bundle/ruby/2.7.0/gems/apipie-rails-1.4.2/lib/apipie/extractor/writer.rb:171:in `load_new_examples'
    	from /home/runner/work/foreman/foreman/vendor/bundle/ruby/2.7.0/gems/apipie-rails-1.4.2/lib/apipie/extractor/writer.rb:134:in `merge_old_new_examples'
    	from /home/runner/work/foreman/foreman/vendor/bundle/ruby/2.7.0/gems/apipie-rails-1.4.2/lib/apipie/extractor/writer.rb:77:in `write_examples'
    	from /home/runner/work/foreman/foreman/vendor/bundle/ruby/2.7.0/gems/apipie-rails-1.4.2/lib/apipie/extractor.rb:81:in `write_examples'
    	from /home/runner/work/foreman/foreman/vendor/bundle/ruby/2.7.0/gems/apipie-rails-1.4.2/lib/apipie/extractor.rb:49:in `finish'
    	from /home/runner/work/foreman/foreman/vendor/bundle/ruby/2.7.0/gems/apipie-rails-1.4.2/lib/apipie/extractor.rb:182:in `block in <top (required)>'
    /home/runner/work/foreman/foreman/vendor/bundle/ruby/2.7.0/gems/minitest-5.25.5/lib/minitest.rb:83:in `exit': exit (SystemExit)
    	from /home/runner/work/foreman/foreman/vendor/bundle/ruby/2.7.0/gems/minitest-5.25.5/lib/minitest.rb:83:in `block (2 levels) in autorun'

While we could guard the writer from this problem, it doesn't really make sense to collect these calls anyway, as the data in there won't be usable.