### PR TITLE
Fix Rails 8.1 router keyword args deprecation warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rails: ["8.0", "7.2", "7.1", "7.0", "6.1", "6.0"]
+        rails: ["8.1", "8.0", "7.2", "7.1", "7.0", "6.1", "6.0"]
         ruby: ["3.4", "3.3", "3.2", "3.1", "3.0", "2.7"]
         include:
           - rails: "5.2"
@@ -33,6 +33,12 @@ jobs:
           - rails: "8.0"
             ruby: "3.0"
           - rails: "8.0"
+            ruby: "3.1"
+          - rails: "8.1"
+            ruby: "2.7"
+          - rails: "8.1"
+            ruby: "3.0"
+          - rails: "8.1"
             ruby: "3.1"
 
     env:

--- a/lib/apipie/routing.rb
+++ b/lib/apipie/routing.rb
@@ -5,7 +5,7 @@ module Apipie
         namespace "apipie", :path => Apipie.configuration.doc_base_url do
           get 'apipie_checksum', :to => "apipies#apipie_checksum", :format => "json"
           constraints(:version => %r{[^/]+}, :resource => %r{[^/]+}, :method => %r{[^/]+}) do
-            get(options.reverse_merge("(:version)/(:resource)/(:method)" => "apipies#index", :as => :apipie))
+            get(**options.reverse_merge("(:version)/(:resource)/(:method)" => "apipies#index", :as => :apipie))
           end
         end
       end

--- a/lib/apipie/routing.rb
+++ b/lib/apipie/routing.rb
@@ -5,7 +5,11 @@ module Apipie
         namespace "apipie", :path => Apipie.configuration.doc_base_url do
           get 'apipie_checksum', :to => "apipies#apipie_checksum", :format => "json"
           constraints(:version => %r{[^/]+}, :resource => %r{[^/]+}, :method => %r{[^/]+}) do
-            get(**options.reverse_merge("(:version)/(:resource)/(:method)" => "apipies#index", :as => :apipie))
+            if Rails.version >= "5.2"
+              get(**options.reverse_merge("(:version)/(:resource)/(:method)" => "apipies#index", :as => :apipie))
+            else
+              get(options.reverse_merge("(:version)/(:resource)/(:method)" => "apipies#index", :as => :apipie))
+            end
           end
         end
       end

--- a/lib/apipie/routing.rb
+++ b/lib/apipie/routing.rb
@@ -5,11 +5,9 @@ module Apipie
         namespace "apipie", :path => Apipie.configuration.doc_base_url do
           get 'apipie_checksum', :to => "apipies#apipie_checksum", :format => "json"
           constraints(:version => %r{[^/]+}, :resource => %r{[^/]+}, :method => %r{[^/]+}) do
-            if Rails.version >= "5.2"
-              get(**options.reverse_merge("(:version)/(:resource)/(:method)" => "apipies#index", :as => :apipie))
-            else
-              get(options.reverse_merge("(:version)/(:resource)/(:method)" => "apipies#index", :as => :apipie))
-            end
+            get_args = options.reverse_merge("(:version)/(:resource)/(:method)" => "apipies#index", :as => :apipie)
+
+            Rails.version >= "5.2" ? get(**get_args) : get(get_args)
           end
         end
       end


### PR DESCRIPTION
Rails 8.1 is raising a deprecation warning on a single line in lib/apipie/routing.rb, where `get` (and all other router methods) will be expected to use keyword arguments from Rails 8.2 onwards.

The initial fix failed in the CI tests for the oldest 2 ruby/rails versions, so I've amended the fix to only apply to Rails 5.2 and above, if the older versions still need to be supported.