### PR TITLE
Add support for x-extension properties in Apipie.prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,6 +809,9 @@ Apipie::prop(<property-name>, <property-type>, <options-hash> [, <array of sub-p
 # options-hash can include any of the options fields allowed in a :returns statement.
 # additionally, it can include the ':is_array => true', in which case the property is understood to be
 # an array of the described type.
+#
+# x-extensions: any option key starting with 'x-' will be passed through to the
+# generated OpenAPI/Swagger specification. This is useful for vendor-specific extensions.
 ```
 
 To describe an embedded object:

--- a/lib/apipie/generator/swagger/param_description/builder.rb
+++ b/lib/apipie/generator/swagger/param_description/builder.rb
@@ -55,6 +55,7 @@ class Apipie::Generator::Swagger::ParamDescription::Builder
     definition.merge!(for_required)
     definition.merge!(for_example)
     definition.merge!(@description.to_hash) if @description.present?
+    definition.merge!(for_x_extensions)
 
     warn_optional_without_default_value(definition)
 
@@ -62,6 +63,10 @@ class Apipie::Generator::Swagger::ParamDescription::Builder
   end
 
   private
+
+  def for_x_extensions
+    @param_description.options.select { |key, _| key.to_s.start_with?('x-') }
+  end
 
   def for_required
     return {} if !required?

--- a/spec/lib/apipie/generator/swagger/param_description/builder_spec.rb
+++ b/spec/lib/apipie/generator/swagger/param_description/builder_spec.rb
@@ -242,4 +242,33 @@ describe Apipie::Generator::Swagger::ParamDescription::Builder do
       it { is_expected.to eq('example') }
     end
   end
+
+  describe 'x-extensions' do
+    context 'when x-extension options are provided' do
+      let(:base_param_description_options) do
+        {
+          required: true,
+          'x-param-sensitive': true,
+          'x-custom-extension': 'custom-value'
+        }
+      end
+
+      it 'includes x-param-sensitive in the output' do
+        expect(generated_block[:'x-param-sensitive']).to eq(true)
+      end
+
+      it 'includes x-custom-extension in the output' do
+        expect(generated_block[:'x-custom-extension']).to eq('custom-value')
+      end
+    end
+
+    context 'when no x-extension options are provided' do
+      let(:base_param_description_options) { { required: true } }
+
+      it 'does not include any x-extension keys' do
+        x_extension_keys = generated_block.keys.select { |k| k.to_s.start_with?('x-') }
+        expect(x_extension_keys).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
In our API spec, we found the need recently to set [`x-extension`](https://swagger.io/docs/specification/v2_0/swagger-extensions/) properties for some of our downstream API spec consumers (which auto generate SDKs based on our api spec).

This PR adds support for setting `x-extensions`.

## Example:
```ruby
Apipie.prop(:password, "password", { description: "The plain text password", "x-param-sensitive": true })
```

```json
"password": {
  "type": "string",
  "description": "The plain text password, available only after create",
  "x-param-sensitive": true
}
```