### PR TITLE
Fix Swagger schema for Array-with-block body params

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1104,6 +1104,7 @@ RSpec/NamedSubject:
     - 'spec/lib/apipie/generator/swagger/param_description/builder_spec.rb'
     - 'spec/lib/apipie/generator/swagger/param_description/type_spec.rb'
     - 'spec/lib/apipie/generator/swagger/param_description_spec.rb'
+    - 'spec/lib/apipie/generator/swagger/type_extractor_spec.rb'
     - 'spec/lib/apipie/generator/swagger/warning_spec.rb'
     - 'spec/lib/apipie/generator/swagger/warning_writer_spec.rb'
     - 'spec/lib/apipie/method_description/apis_service_spec.rb'
@@ -1242,6 +1243,7 @@ Rails/Output:
     - 'lib/apipie/apipie_module.rb'
     - 'lib/apipie/extractor.rb'
     - 'lib/apipie/rspec/response_validation_helper.rb'
+    - 'spec/lib/swagger/swagger_dsl_spec.rb'
 
 # Offense count: 2
 Rails/OutputSafety:
@@ -1725,6 +1727,9 @@ Style/RedundantInterpolation:
 Style/RedundantParentheses:
   Exclude:
     - 'lib/apipie/extractor/collector.rb'
+    - 'lib/apipie/param_description.rb'
+    - 'lib/tasks/apipie.rake'
+    - 'spec/lib/swagger/rake_swagger_spec.rb'
 
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).
@@ -1965,3 +1970,69 @@ Style/ZeroLengthPredicate:
   Exclude:
     - 'lib/apipie/generator/swagger/param_description/composite.rb'
     - 'spec/lib/swagger/swagger_dsl_spec.rb'
+
+# Offense count: 8
+Naming/PredicateMethod:
+  Exclude:
+    - 'app/controllers/apipie/apipies_controller.rb'
+    - 'lib/apipie/response_description.rb'
+    - 'lib/apipie/static_dispatcher.rb'
+    - 'lib/apipie/validator.rb'
+    - 'spec/dummy/config/initializers/apipie.rb'
+    - 'spec/spec_helper.rb'
+    - 'spec/support/custom_bool_validator.rb'
+
+# Offense count: 17
+# This cop supports unsafe autocorrection (--autocorrect-all).
+RSpec/Output:
+  Exclude:
+    - 'spec/lib/swagger/swagger_dsl_spec.rb'
+
+# Offense count: 32
+# This cop supports safe autocorrection (--autocorrect).
+RSpecRails/MinitestAssertions:
+  Exclude:
+    - 'spec/controllers/concerns_controller_spec.rb'
+    - 'spec/controllers/users_controller_spec.rb'
+    - 'spec/lib/apipie/apipies_controller_spec.rb'
+
+# Offense count: 3
+# This cop supports safe autocorrection (--autocorrect).
+Rails/ActionOrder:
+  Exclude:
+    - 'spec/dummy/app/controllers/overridden_concerns_controller.rb'
+    - 'spec/dummy/app/controllers/twitter_example_controller.rb'
+    - 'spec/dummy/app/controllers/users_controller.rb'
+
+# Offense count: 2
+# This cop supports unsafe autocorrection (--autocorrect-all).
+Style/CollectionQuerying:
+  Exclude:
+    - 'lib/apipie/generator/swagger/warning_writer.rb'
+    - 'lib/apipie/see_description.rb'
+
+# Offense count: 1
+Style/FileOpen:
+  Exclude:
+    - 'lib/apipie/dsl_definition.rb'
+
+# Offense count: 1
+# This cop supports safe autocorrection (--autocorrect).
+Style/ModuleMemberExistenceCheck:
+  Exclude:
+    - 'lib/apipie/dsl_definition.rb'
+
+# Offense count: 10
+Style/OneClassPerFile:
+  Exclude:
+    - 'lib/apipie/core_ext/route.rb'
+    - 'lib/apipie/extractor.rb'
+    - 'lib/apipie/rspec/response_validation_helper.rb'
+    - 'spec/dummy/app/controllers/pets_using_auto_views_controller.rb'
+    - 'spec/dummy/app/controllers/pets_using_self_describing_classes_controller.rb'
+
+# Offense count: 3
+# This cop supports unsafe autocorrection (--autocorrect-all).
+Style/ReduceToHash:
+  Exclude:
+    - 'lib/apipie/generator/swagger/method_description/response_service.rb'

--- a/lib/apipie/generator/swagger/type_extractor.rb
+++ b/lib/apipie/generator/swagger/type_extractor.rb
@@ -31,6 +31,8 @@ class Apipie::Generator::Swagger::TypeExtractor
         :string
       elsif enum?
         :enum
+      elsif nested?
+        :hash
       else
         @validator.expected_type.to_sym
       end
@@ -47,5 +49,9 @@ class Apipie::Generator::Swagger::TypeExtractor
   def enum?
     @validator.is_a?(Apipie::Validator::EnumValidator) ||
       (@validator.respond_to?(:is_enum?) && @validator.is_enum?)
+  end
+
+  def nested?
+    @validator.is_a?(Apipie::Validator::NestedValidator)
   end
 end

--- a/lib/apipie/param_description.rb
+++ b/lib/apipie/param_description.rb
@@ -14,7 +14,10 @@ module Apipie
 
     alias response_only? response_only
     alias request_only? request_only
-    alias is_array? is_array
+
+    def is_array?
+      @is_array || @validator.is_a?(Apipie::Validator::NestedValidator)
+    end
 
     def self.from_dsl_data(method_description, args)
       param_name, validator, desc_or_options, options, block = args

--- a/spec/lib/apipie/generator/swagger/type_extractor_spec.rb
+++ b/spec/lib/apipie/generator/swagger/type_extractor_spec.rb
@@ -34,5 +34,20 @@ describe Apipie::Generator::Swagger::TypeExtractor do
     subject { extractor.extract }
 
     it_behaves_like 'extractable method'
+
+    context 'with a NestedValidator (param :foo, Array do … end)' do
+      let(:resource_desc) { Apipie::ResourceDescription.new(UsersController, 'users') }
+      let(:method_desc) do
+        Apipie::MethodDescription.new(:show, resource_desc, ActionController::Base.send(:_apipie_dsl_data_init))
+      end
+      let(:param_description) do
+        Apipie::ParamDescription.new(method_desc, :things, Array) { param :name, String }
+      end
+      let(:validator) { param_description.validator }
+
+      it 'is extracted as object so the nested-schema branch in Composite runs' do
+        expect(subject).to eq(Apipie::Generator::Swagger::TypeExtractor::TYPES[:hash])
+      end
+    end
   end
 end

--- a/spec/lib/apipie/param_description_spec.rb
+++ b/spec/lib/apipie/param_description_spec.rb
@@ -550,6 +550,25 @@ describe Apipie::ParamDescription do
     end
   end
 
+  describe '#is_array?' do
+    it 'is true when array_of option is used' do
+      param = Apipie::ParamDescription.new(method_desc, :param, array_of: String, only_in: :response)
+      expect(param).to be_is_array
+    end
+
+    it 'is true when Array is used with a block of nested params' do
+      param = Apipie::ParamDescription.new(method_desc, :param, Array) do
+        param :name, String
+      end
+      expect(param).to be_is_array
+    end
+
+    it 'is false for a plain scalar param' do
+      param = Apipie::ParamDescription.new(method_desc, :param, String)
+      expect(param).not_to be_is_array
+    end
+  end
+
   describe '#deprecated?' do
     subject do
       Apipie::ParamDescription.new(method_desc, :param, Integer, options)

--- a/spec/lib/apipie/param_description_spec.rb
+++ b/spec/lib/apipie/param_description_spec.rb
@@ -557,10 +557,10 @@ describe Apipie::ParamDescription do
     end
 
     it 'is true when Array is used with a block of nested params' do
-      param = Apipie::ParamDescription.new(method_desc, :param, Array) do
+      description = Apipie::ParamDescription.new(method_desc, :param, Array) do
         param :name, String
       end
-      expect(param).to be_is_array
+      expect(description).to be_is_array
     end
 
     it 'is false for a plain scalar param' do


### PR DESCRIPTION
Related to #895.

- `param :foo, Array do … end` produces a `NestedValidator` with `expected_type` `"array"`.
- `ParamDescription::Composite#to_swagger` only recurses into the nested-schema branch when `extract` returns `"object"`, so `NestedValidator` falls through and Swagger emits `items: { type: "string" }`.
- Fix: `TypeExtractor#extract` returns `"object"` for `NestedValidator`, and `ParamDescription#is_array?` returns true. The existing `for_array` path then wraps the generated nested schema.