### PR TITLE
Make RDoc.to_html compatible with rdoc-8.0

### DIFF
--- a/lib/apipie/markup.rb
+++ b/lib/apipie/markup.rb
@@ -16,10 +16,11 @@ module Apipie
       private
 
       def rdoc
-        if Gem::Version.new(::RDoc::VERSION) < Gem::Version.new('4.0.0')
-          ::RDoc::Markup::ToHtml.new()
-        else
+        rdoc_version = Gem::Version.new(::RDoc::VERSION)
+        if rdoc_version >= Gem::Version.new('4.0.0') && rdoc_version < Gem::Version.new('8.0.0')
           ::RDoc::Markup::ToHtml.new(::RDoc::Options.new)
+        else
+          ::RDoc::Markup::ToHtml.new()
         end
       end
     end

--- a/spec/support/rake.rb
+++ b/spec/support/rake.rb
@@ -6,6 +6,7 @@ shared_context "rake" do
   let(:task_name) { rake.parse_task_string(self.class.description).first }
   let(:task_args) { rake.parse_task_string(self.class.description).last }
   let(:task_path) { "lib/tasks/apipie" }
+
   subject         { rake[task_name] }
 
   def loaded_files_excluding_current_rake_file


### PR DESCRIPTION
RDoc changed the signature for ToHtml.new once more in 8.0.0: https://github.com/ruby/rdoc/blob/v8.0.0/lib/rdoc/markup/to_html.rb#L127