### PR TITLE
Allow overriding the generated operationId per route

### DIFF
--- a/README.md
+++ b/README.md
@@ -1748,6 +1748,18 @@ example:
 param :do_something, Boolean, :desc => "take an action", :required => false, :default_value => false
 ```
 
+## Specifying a custom operationId
+
+By default, the `operationId` of each generated swagger operation is
+derived from its HTTP method and path (e.g. `get_api_users_id`). To
+use a custom value instead (for example to match the naming your
+client code generator expects), pass `:operation_id` in the `api` DSL
+call:
+
+``` ruby
+api :GET, "/api/users/:id", "Show user", :operation_id => "showUser"
+```
+
 ## Generated Warnings
 
 The help identify potential improvements to your documentation, the

--- a/lib/apipie/generator/swagger/method_description/api_schema_service.rb
+++ b/lib/apipie/generator/swagger/method_description/api_schema_service.rb
@@ -10,7 +10,7 @@ class Apipie::Generator::Swagger::MethodDescription::ApiSchemaService
     @method_description.apis.each_with_object({}) do |api, paths|
       api = Apipie::Generator::Swagger::MethodDescription::ApiDecorator.new(api)
       path = Apipie::Generator::Swagger::PathDecorator.new(api.path)
-      op_id = Apipie::Generator::Swagger::OperationId.from(api).to_s
+      op_id = api.options[:operation_id] || Apipie::Generator::Swagger::OperationId.from(api).to_s
 
       if Apipie.configuration.generator.swagger.generate_x_computed_id_field?
         Apipie::Generator::Swagger::ComputedInterfaceId.instance.add!(op_id)

--- a/spec/lib/apipie/generator/swagger/method_description/api_schema_service_spec.rb
+++ b/spec/lib/apipie/generator/swagger/method_description/api_schema_service_spec.rb
@@ -6,6 +6,7 @@ describe Apipie::Generator::Swagger::MethodDescription::ApiSchemaService do
   let(:resource_id) { 'users' }
   let(:method_description_description) { nil }
   let(:tags) { [] }
+  let(:api_options) { { deprecated: true } }
 
   let(:dsl_data) do
     ActionController::Base
@@ -13,7 +14,7 @@ describe Apipie::Generator::Swagger::MethodDescription::ApiSchemaService do
       .merge(
         {
           description: method_description_description,
-          api_args: [[http_method, path, 'Some api description', { deprecated: true }]],
+          api_args: [[http_method, path, 'Some api description', api_options]],
           tag_list: tags
         }
       )
@@ -102,6 +103,18 @@ describe Apipie::Generator::Swagger::MethodDescription::ApiSchemaService do
       before { Apipie.configuration.generator.swagger.content_type_input = :json }
 
       it { is_expected.to eq(['application/json']) }
+    end
+  end
+
+  describe 'operationId' do
+    subject { service.call[path][http_method][:operationId] }
+
+    it { is_expected.to eq(Apipie::Generator::Swagger::OperationId.new(path: path, http_method: http_method).to_s) }
+
+    context 'when the operation_id option is given' do
+      let(:api_options) { { operation_id: 'customOperationId' } }
+
+      it { is_expected.to eq('customOperationId') }
     end
   end
 


### PR DESCRIPTION
## Summary

Right now the swagger `operationId` for every route is always derived purely from the HTTP method + path (`Apipie::Generator::Swagger::OperationId`), e.g. `get_api_users_id`. There's no way to override it, which is awkward for consumers of the generated OpenAPI spec (e.g. client code generators) that key off `operationId` for method naming.

This adds an `:operation_id` option to the `api` DSL, following the exact same pattern already used by the existing `:deprecated` option (read from `api.options`):

```ruby
api :GET, "/api/users/:id", "Show user", :operation_id => "showUser"
```

If `:operation_id` isn't given, behavior is unchanged (falls back to the existing auto-derived id).

## Changes

- `lib/apipie/generator/swagger/method_description/api_schema_service.rb`: prefer `api.options[:operation_id]` over the auto-generated id when present.
- `spec/.../api_schema_service_spec.rb`: added coverage for both the default and custom-id cases.
- `README.md`: documented the new option alongside the other swagger-specific DSL options.

## Test plan

- [x] `bundle exec rspec spec/lib/apipie/generator/swagger/method_description/api_schema_service_spec.rb spec/lib/apipie/generator/swagger/operation_id_spec.rb` — 19 examples, 0 failures
- [x] Verified no behavior change when `:operation_id` is omitted (existing tests for auto-derived ids still pass)