### PR TITLE
Recurse into nested params for request-body Array items, not just Hash

### DIFF
--- a/lib/apipie/generator/swagger/param_description/composite.rb
+++ b/lib/apipie/generator/swagger/param_description/composite.rb
@@ -25,7 +25,15 @@ class Apipie::Generator::Swagger::ParamDescription::Composite
         new(param_description.validator).
         extract
 
-      has_nested_params = param_type == 'object' &&
+      # `param :foo, Array do ... end` builds a NestedValidator (an
+      # ArrayValidator is only built when no block is given), whose own
+      # expected_type is 'array' -- but it delegates params_ordered to an
+      # internal HashValidator, so it does have a nested schema to recurse
+      # into even though param_type isn't 'object'.
+      nested_array = param_type == 'array' &&
+        param_description.validator.respond_to?(:params_ordered)
+
+      has_nested_params = (param_type == 'object' || nested_array) &&
         param_description.validator.params_ordered.present?
 
       if has_nested_params
@@ -44,7 +52,7 @@ class Apipie::Generator::Swagger::ParamDescription::Composite
           schema[:additionalProperties] = true
         end
 
-        if param_description.is_array?
+        if param_description.is_array? || nested_array
           schema = for_array(schema)
         end
 

--- a/spec/lib/apipie/generator/swagger/param_description/composite_spec.rb
+++ b/spec/lib/apipie/generator/swagger/param_description/composite_spec.rb
@@ -74,6 +74,38 @@ describe Apipie::Generator::Swagger::ParamDescription::Composite do
     end
   end
 
+  describe 'array of nested params' do
+    # `param :some_param, Array do ... end` (no `of:`/`array_of:` option)
+    # builds a NestedValidator, whose own params (declared in the block)
+    # should still be recursed into and rendered as the array's `items`
+    # schema, not silently collapsed to `{ type: 'array', items: { type: 'string' } }`.
+    let(:params_description_one) do
+      Apipie::ParamDescription.new(method_description, :some_param, Array) do
+        param :nested_field, String, required: true
+        param :other_field, Integer
+      end
+    end
+
+    let(:param_descriptions) { [params_description_one] }
+
+    subject { swagger[:properties][:some_param] }
+
+    it 'renders the item schema from the nested params instead of falling back to string items' do
+      expect(subject).to eq(
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            nested_field: { type: 'string' },
+            other_field: { type: 'integer', format: 'int32' }
+          },
+          additionalProperties: false,
+          required: [ :nested_field ]
+        }
+      )
+    end
+  end
+
   describe 'required' do
     subject { swagger[:required] }
 


### PR DESCRIPTION
## Problem

`param :foo, Array do ... end` (no `of:`/`array_of:` option) builds a `NestedValidator` rather than an `ArrayValidator` -- `ArrayValidator.build` explicitly refuses to build when a block is given:

```ruby
def self.build(param_description, argument, options, block)
  self.new(param_description, argument, options) if argument == Array && !block.is_a?(Proc)
end
```

`NestedValidator`'s own `expected_type` is `"array"`, but it delegates `params_ordered` to an internal `HashValidator`, so it does carry a full nested schema for the array's items.

`Composite#to_swagger`'s `has_nested_params` check only recurses when `param_type == 'object'`:

```ruby
has_nested_params = param_type == 'object' &&
  param_description.validator.params_ordered.present?
```

Since `NestedValidator#expected_type` is `"array"`, this never matches, so the nested params are silently discarded and the array's items collapse to a bare `{ type: 'string' }` -- even though the equivalent response-side entity (`returns` / `describe_own_properties`) documents the exact same shape correctly.

This is easy to hit in practice: any request body with an array of objects, declared the same way apipie's own docs show a plain nested `Hash` param, loses its item schema entirely, with no warning that anything was lost.

## Fix

Extend the nested-params check to also recognize this case (an `expected_type == 'array'` validator that responds to `params_ordered`, i.e. a `NestedValidator`), recurse into it the same way, and wrap the result as an array schema -- mirroring how `is_array?` already wraps the plain-Hash case.

## Verification

Reproduced and fixed against a real downstream Rails app (not just the added spec): a controller with `param :reviews, Array do ... end` (nested `param`s for each review field) generated `"reviews": { "type": "array", "items": { "type": "string" } }` in the swagger doc before this change. After patching the installed gem with this fix and regenerating, it produced the full nested object schema, matching what the response side already documented for the same shape. Reverted the local patch after confirming, and added a spec covering the same scenario (`spec/lib/apipie/generator/swagger/param_description/composite_spec.rb`).